### PR TITLE
Clean up for 1.0.0.rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         ruby:
         - "3.1"
         - "3.0"
-        - "2.7"
         include:
           - ruby: "3.1"
             coverage: "true"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  SuggestExtensions: false
   Exclude:
     - benchmarks/*.rb
     - spec/support/coverage.rb

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require "rake"
 require "bundler/gem_tasks"
 
 require "rspec/core/rake_task"
-require "rspec/core/rake_task"
 
 task default: :spec
 

--- a/dry-logger.gemspec
+++ b/dry-logger.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"]   = "https://github.com/dry-rb/dry-logger"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/dry-rb/dry-logger/issues"
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0"
 
   # to update dependencies edit project.yml
 

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -12,21 +12,32 @@ require "dry/logger/backends/file"
 module Dry
   # Set up a logger dispatcher
   #
-  # @example
-  # .  logger = Dry.Logger(:my_app)
-  #    logger.info("Hello World!")
-  #    # Hello World!
+  # @example Basic $stdout string logger
+  #   logger = Dry.Logger(:my_app)
   #
-  # .  logger = Dry.Logger(:my_app, formatter: :string, template: "[%<severity>][%<time>s] %<message>s")
+  #   logger.info("Hello World!")
+  #   # Hello World!
   #
-  #    logger.info("Hello World!")
-  #    # [INFO][2022-11-06 10:55:12 +0100] Hello World!
+  # @example Customized $stdout string logger
+  #   logger = Dry.Logger(:my_app, template: "[%<severity>][%<time>s] %<message>s")
   #
-  #    logger.warn("Ooops!")
-  #    # [WARN][2022-11-06 10:55:57 +0100] Ooops!
+  #   logger.info("Hello World!")
+  #   # [INFO][2022-11-06 10:55:12 +0100] Hello World!
   #
-  #    logger.warn("Gaaah!")
-  #    # [ERROR][2022-11-06 10:55:57 +0100] Gaaah!
+  #   logger.info(Hello: "World!")
+  #   # [INFO][2022-11-06 10:55:14 +0100] Hello="World!"
+  #
+  #   logger.warn("Ooops!")
+  #   # [WARN][2022-11-06 10:55:57 +0100] Ooops!
+  #
+  #   logger.warn("Gaaah!")
+  #   # [ERROR][2022-11-06 10:55:57 +0100] Gaaah!
+  #
+  # @example Basic $stdout JSON logger
+  #   logger = Dry.Logger(:my_app, formatter: :json)
+  #
+  #   logger.info(Hello: "World!")
+  #   # {"progname":"my_app","severity":"INFO","time":"2022-11-06T10:11:29Z","Hello":"World!"}
   #
   # @since 1.0.0
   # @return [Dispatcher]
@@ -42,8 +53,8 @@ module Dry
     #   class MyFormatter < Dry::Logger::Formatters::Structured
     #     def format(entry)
     #       "WOAH: #{entry.message}"
-    # .   end
-    # . end
+    #     end
+    #   end
     #
     #   Dry::Logger.register_formatter(MyFormatter)
     #

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -4,6 +4,7 @@ require "dry/logger/constants"
 require "dry/logger/dispatcher"
 
 require "dry/logger/formatters/string"
+require "dry/logger/formatters/params"
 require "dry/logger/formatters/json"
 
 require "dry/logger/backends/io"
@@ -106,6 +107,7 @@ module Dry
     end
 
     register_formatter(:string, Formatters::String)
+    register_formatter(:params, Formatters::Params)
     register_formatter(:json, Formatters::JSON)
   end
 end

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -6,14 +6,92 @@ require "dry/logger/dispatcher"
 require "dry/logger/formatters/string"
 require "dry/logger/formatters/json"
 
-module Dry
-  module Logger
-    def self.formatters
-      @formatters ||= {}
-    end
+require "dry/logger/backends/io"
+require "dry/logger/backends/file"
 
+module Dry
+  # Set up a logger dispatcher
+  #
+  # @example
+  # .  logger = Dry.Logger(:my_app)
+  #    logger.info("Hello World!")
+  #    # Hello World!
+  #
+  # .  logger = Dry.Logger(:my_app, formatter: :string, template: "[%<severity>][%<time>s] %<message>s")
+  #
+  #    logger.info("Hello World!")
+  #    # [INFO][2022-11-06 10:55:12 +0100] Hello World!
+  #
+  #    logger.warn("Ooops!")
+  #    # [WARN][2022-11-06 10:55:57 +0100] Ooops!
+  #
+  #    logger.warn("Gaaah!")
+  #    # [ERROR][2022-11-06 10:55:57 +0100] Gaaah!
+  #
+  # @since 1.0.0
+  # @return [Dispatcher]
+  # @api public
+  def self.Logger(id, **opts, &block)
+    Logger::Dispatcher.setup(id, **opts, &block)
+  end
+
+  module Logger
+    # Register a new formatter
+    #
+    # @example
+    #   class MyFormatter < Dry::Logger::Formatters::Structured
+    #     def format(entry)
+    #       "WOAH: #{entry.message}"
+    # .   end
+    # . end
+    #
+    #   Dry::Logger.register_formatter(MyFormatter)
+    #
+    # @since 1.0.0
+    # @return [Hash]
+    # @api public
     def self.register_formatter(name, formatter)
       formatters[name] = formatter
+      formatters
+    end
+
+    # Build a logging backend instance
+    #
+    # @since 1.0.0
+    # @return [Backends::Stream]
+    # @api private
+    def self.new(stream: $stdout, **opts)
+      backend =
+        case stream
+        when IO, StringIO then Backends::IO
+        when String, Pathname then Backends::File
+        else
+          raise ArgumentError, "unsupported stream type #{stream.class}"
+        end
+
+      formatter_opt = opts[:formatter]
+
+      formatter =
+        case formatter_opt
+        when Symbol then formatters.fetch(formatter_opt).new(**opts)
+        when Class then formatter_opt.new(**opts)
+        when NilClass then formatters[:string].new(**opts)
+        when ::Logger::Formatter then formatter_opt
+        else
+          raise ArgumentError, "unsupported formatter option #{formatter_opt.inspect}"
+        end
+
+      backend_opts = opts.select { |key, _| BACKEND_OPT_KEYS.include?(key) }
+
+      backend.new(stream: stream, **backend_opts, formatter: formatter)
+    end
+
+    # Internal formatters registry
+    #
+    # @since 1.0.0
+    # @api private
+    def self.formatters
+      @formatters ||= {}
     end
 
     register_formatter(:string, Formatters::String)

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -30,7 +30,7 @@ module Dry
   #   logger.warn("Ooops!")
   #   # [WARN][2022-11-06 10:55:57 +0100] Ooops!
   #
-  #   logger.warn("Gaaah!")
+  #   logger.error("Gaaah!")
   #   # [ERROR][2022-11-06 10:55:57 +0100] Gaaah!
   #
   # @example Basic $stdout JSON logger

--- a/lib/dry/logger/backends/stream.rb
+++ b/lib/dry/logger/backends/stream.rb
@@ -18,7 +18,7 @@ module Dry
 
         # @since 0.1.0
         # @api private
-        def initialize(stream:, level: DEFAULT_LEVEL, formatter:, progname: nil)
+        def initialize(stream:, formatter:, level: DEFAULT_LEVEL, progname: nil)
           super(stream, progname: progname)
 
           @stream = stream

--- a/lib/dry/logger/constants.rb
+++ b/lib/dry/logger/constants.rb
@@ -4,6 +4,10 @@ require "logger"
 
 module Dry
   module Logger
+    LOG_METHODS = %i[debug error fatal info warn].freeze
+
+    BACKEND_METHODS = %i[close].freeze
+
     DEBUG = ::Logger::DEBUG
     INFO = ::Logger::INFO
     WARN = ::Logger::WARN

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -88,8 +88,14 @@ module Dry
         end
       end
 
-      def log(meth, ...)
-        call(meth, Entry.build(id, meth, ...))
+      def log(severity, message = nil, **payload)
+        case message
+        when String, Symbol, Array, Exception
+          call(severity, Entry.new(progname: id, severity: severity, message: message, payload: payload))
+        when Hash
+          call(severity, Entry.new(progname: id, severity: severity, payload: message))
+        end
+
         true
       end
 

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -6,45 +6,12 @@ require "pathname"
 require "dry/logger/constants"
 require "dry/logger/entry"
 
-require "dry/logger/backends/io"
-require "dry/logger/backends/file"
-
 module Dry
-  def self.Logger(id, **opts, &block)
-    Logger::Dispatcher.setup(id, **opts, &block)
-  end
-
   module Logger
-    LOG_METHODS = %i[debug error fatal info warn].freeze
-
-    BACKEND_METHODS = %i[close].freeze
-
-    def self.new(stream: $stdout, **opts)
-      backend =
-        case stream
-        when IO, StringIO then Backends::IO
-        when String, Pathname then Backends::File
-        else
-          raise ArgumentError, "unsupported stream type #{stream.class}"
-        end
-
-      formatter_opt = opts[:formatter]
-
-      formatter =
-        case formatter_opt
-        when Symbol then formatters.fetch(formatter_opt).new(**opts)
-        when Class then formatter_opt.new(**opts)
-        when NilClass then formatters[:string].new(**opts)
-        when ::Logger::Formatter then formatter_opt
-        else
-          raise ArgumentError, "unsupported formatter option #{formatter_opt.inspect}"
-        end
-
-      backend_opts = opts.select { |key, _| BACKEND_OPT_KEYS.include?(key) }
-
-      backend.new(stream: stream, **backend_opts, formatter: formatter)
-    end
-
+    # Logger dispatcher routes log entries to configured logging backends
+    #
+    # @since 1.0.0
+    # @api public
     class Dispatcher
       attr_reader :id
 

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -106,7 +106,10 @@ module Dry
       def log(severity, message = nil, **payload)
         case message
         when String, Symbol, Array, Exception
-          call(severity, Entry.new(progname: id, severity: severity, message: message, payload: payload))
+          call(
+            severity,
+            Entry.new(progname: id, severity: severity, message: message, payload: payload)
+          )
         when Hash
           call(severity, Entry.new(progname: id, severity: severity, payload: message))
         end

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -13,12 +13,27 @@ module Dry
     # @since 1.0.0
     # @api public
     class Dispatcher
+      # @since 1.0.0
+      # @api private
       attr_reader :id
 
+      # @since 1.0.0
+      # @api private
       attr_reader :backends
 
+      # @since 1.0.0
+      # @api private
       attr_reader :opts
 
+      # Set up a dispatcher
+      #
+      # @since 1.0.0
+      #
+      # @param [String, Symbol] id The dispatcher id, can be used as progname in log entries
+      # @param [Hash] **opts Options that can be used for both the backend and formatter
+      #
+      # @return [Dispatcher]
+      # @api public
       def self.setup(id, **opts)
         if opts.empty?
           new(id, backends: [Dry::Logger.new(**DEFAULT_OPTS)], **DEFAULT_OPTS)
@@ -27,6 +42,29 @@ module Dry
         end
       end
 
+      # @!method debug(message = nil, **payload)
+      #   Log an entry with DEBUG severity
+      #   @see Dispatcher#log
+      #   @api public
+      #   @return [true]
+      # @!method info(message = nil, **payload)
+      #   Log an entry with INFO severity
+      #   @see Dispatcher#log
+      #   @api public
+      #   @return [true]
+      #   @api public
+      # @!method warn(message = nil, **payload)
+      #   Log an entry with WARN severity
+      #   @see Dispatcher#log
+      #   @api public
+      #   @return [true]
+      #   @api public
+      # @!method error(message = nil, **payload)
+      #   Log an entry with ERROR severity
+      #   @see Dispatcher#log
+      #   @api public
+      #   @return [true]
+      #   @api public
       LOG_METHODS.each do |name|
         define_method(name) do |*args|
           log(name, *args)
@@ -39,22 +77,32 @@ module Dry
         end
       end
 
+      # @since 1.0.0
+      # @api private
       def initialize(id, backends:, **opts)
         @id = id
         @backends = backends
         @opts = opts
       end
 
+      # Return severity level
+      #
+      # @since 1.0.0
+      # @return [Integer]
+      # @api public
       def level
         LEVELS[opts[:level]]
       end
 
-      def call(meth, ...)
-        backends.each do |backend|
-          backend.public_send(meth, ...)
-        end
-      end
-
+      # Pass logging to all configured backends
+      #
+      # @param [Symbol] severity The log severity name
+      # @param [String,Symbol,Array] message Optional message object
+      # @param [Hash] **payload Optional log entry payload
+      #
+      # @since 1.0.0
+      # @return [true]
+      # @api public
       def log(severity, message = nil, **payload)
         case message
         when String, Symbol, Array, Exception
@@ -66,9 +114,26 @@ module Dry
         true
       end
 
+      # Add a new backend to an existing dispatcher
+      #
+      # @since 1.0.0
+      # @return [Dispatcher]
+      # @api public
       def add_backend(backend = nil, **opts)
         backends << (backend || Dry::Logger.new(**opts))
         self
+      end
+
+      # Pass logging to all configured backends
+      #
+      # @since 1.0.0
+      # @return [true]
+      # @api private
+      def call(meth, ...)
+        backends.each do |backend|
+          backend.public_send(meth, ...)
+        end
+        true
       end
     end
   end

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -4,6 +4,7 @@ require "logger"
 require "pathname"
 
 require "dry/logger/constants"
+require "dry/logger/entry"
 
 require "dry/logger/backends/io"
 require "dry/logger/backends/file"
@@ -81,14 +82,14 @@ module Dry
         LEVELS[opts[:level]]
       end
 
-      def call(meth, *args)
+      def call(meth, ...)
         backends.each do |backend|
-          backend.public_send(meth, *args)
+          backend.public_send(meth, ...)
         end
       end
 
-      def log(meth, *args)
-        call(meth, *args)
+      def log(meth, ...)
+        call(meth, Entry.build(id, meth, ...))
         true
       end
 

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -69,8 +69,8 @@ module Dry
 
       # @since 1.0.0
       # @api public
-      def params?
-        payload.key?(:params)
+      def key?(name)
+        payload.key?(name)
       end
 
       # @since 1.0.0

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "dry/logger/constants"
+
+module Dry
+  module Logger
+    # @since 1.0.0
+    # @api public
+    class Entry
+      include Enumerable
+
+      # @since 1.0.0
+      # @api private
+      EMPTY_PAYLOAD = {}.freeze
+
+      # @since 1.0.0
+      # @api private
+      EMPTY_BACKTRACE = [].freeze
+
+      # @since 1.0.0
+      # @api private
+      def self.build(progname, severity, ...)
+        new(progname: progname, severity: severity, message: message(...), payload: payload(...))
+      end
+
+      # @since 1.0.0
+      # @api private
+      def self.message(*args, **)
+        case (value = args[0])
+        when String, Array, Symbol, Exception then value
+        when Hash then nil
+        else
+          raise ArgumentError, "+#{value}+ must be either a String or a Hash (#{value.class} given)"
+        end
+      end
+
+      # @since 1.0.0
+      # @api private
+      def self.payload(*args, **payload)
+        case (value = args[0])
+        when String then EMPTY_PAYLOAD
+        when Hash then value
+        else
+          payload
+        end
+      end
+
+      # @since 1.0.0
+      # @api public
+      attr_reader :progname
+
+      # @since 1.0.0
+      # @api public
+      attr_reader :severity
+
+      # @since 1.0.0
+      # @api public
+      attr_reader :time
+
+      # @since 1.0.0
+      # @api public
+      attr_reader :message
+      alias exception message
+
+      # @since 1.0.0
+      # @api public
+      attr_reader :payload
+
+      # @since 1.0.0
+      # @api private
+      def initialize(progname:, severity:, time: Time.now, message:, payload:)
+        @progname = progname
+        @severity = severity.to_s.upcase # TODO: this doesn't feel right
+        @time = time
+        @message = message
+        @payload = build_payload(payload)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def each(&block)
+        payload.each(&block)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def [](name)
+        payload[name]
+      end
+
+      # @since 1.0.0
+      # @api public
+      def exception?
+        message.is_a?(Exception)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def params?
+        payload.key?(:params)
+      end
+
+      # @since 1.0.0
+      # @api private
+      def to_h
+        @to_h ||= meta.merge(payload)
+      end
+
+      # @since 1.0.0
+      # @api private
+      def meta
+        @meta ||= {progname: progname, severity: severity, time: time}
+      end
+
+      # @since 1.0.0
+      # @api private
+      def utc_time
+        @utc_time ||= time.utc.iso8601
+      end
+
+      # @since 1.0.0
+      # @api private
+      def as_json
+        # TODO: why are we enforcing UTC in JSON but not in String?
+        @as_json ||= to_h.merge(message: message, time: utc_time).compact
+      end
+
+      # @since 1.0.0
+      # @api private
+      def filter(filter)
+        @payload = filter.call(payload)
+        self
+      end
+
+      private
+
+      # @since 1.0.0
+      # @api private
+      def build_payload(payload)
+        if exception?
+          {message: exception.message,
+           backtrace: exception.backtrace || EMPTY_BACKTRACE,
+           error: exception.class,
+           **payload}
+        else
+          payload
+        end
+      end
+
+    end
+  end
+end

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -19,34 +19,6 @@ module Dry
       EMPTY_BACKTRACE = [].freeze
 
       # @since 1.0.0
-      # @api private
-      def self.build(progname, severity, ...)
-        new(progname: progname, severity: severity, message: message(...), payload: payload(...))
-      end
-
-      # @since 1.0.0
-      # @api private
-      def self.message(*args, **)
-        case (value = args[0])
-        when String, Array, Symbol, Exception then value
-        when Hash then nil
-        else
-          raise ArgumentError, "+#{value}+ must be either a String or a Hash (#{value.class} given)"
-        end
-      end
-
-      # @since 1.0.0
-      # @api private
-      def self.payload(*args, **payload)
-        case (value = args[0])
-        when String then EMPTY_PAYLOAD
-        when Hash then value
-        else
-          payload
-        end
-      end
-
-      # @since 1.0.0
       # @api public
       attr_reader :progname
 
@@ -69,7 +41,7 @@ module Dry
 
       # @since 1.0.0
       # @api private
-      def initialize(progname:, severity:, time: Time.now, message:, payload:)
+      def initialize(progname:, severity:, time: Time.now, message: nil, payload: EMPTY_PAYLOAD)
         @progname = progname
         @severity = severity.to_s.upcase # TODO: this doesn't feel right
         @time = time

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -33,7 +33,7 @@ module Dry
       # @since 1.0.0
       # @api public
       attr_reader :message
-      alias exception message
+      alias_method :exception, :message
 
       # @since 1.0.0
       # @api public
@@ -119,7 +119,6 @@ module Dry
           payload
         end
       end
-
     end
   end
 end

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "time"
 require "dry/logger/constants"
 
 module Dry

--- a/lib/dry/logger/formatters/json.rb
+++ b/lib/dry/logger/formatters/json.rb
@@ -15,7 +15,7 @@ module Dry
         # @since 0.1.0
         # @api private
         def format(entry)
-          ::JSON.generate(entry.as_json)
+          "#{::JSON.generate(entry.as_json)}#{NEW_LINE}"
         end
       end
     end

--- a/lib/dry/logger/formatters/json.rb
+++ b/lib/dry/logger/formatters/json.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-
-require "dry/logger/formatters/string"
+require "dry/logger/formatters/structured"
 
 module Dry
   module Logger
@@ -12,10 +11,10 @@ module Dry
       #
       # @since 0.1.0
       # @api private
-      class JSON < Formatters::String
+      class JSON < Structured
         # @since 0.1.0
         # @api private
-        def call(_severity, _time, _progname, entry)
+        def format(entry)
           ::JSON.generate(entry.as_json)
         end
       end

--- a/lib/dry/logger/formatters/json.rb
+++ b/lib/dry/logger/formatters/json.rb
@@ -13,13 +13,10 @@ module Dry
       # @since 0.1.0
       # @api private
       class JSON < Formatters::String
-        private
-
         # @since 0.1.0
         # @api private
-        def _format(hash)
-          hash[:time] = hash[:time].utc.iso8601
-          ::JSON.generate(hash) + NEW_LINE
+        def call(_severity, _time, _progname, entry)
+          ::JSON.generate(entry.as_json)
         end
       end
     end

--- a/lib/dry/logger/formatters/params.rb
+++ b/lib/dry/logger/formatters/params.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "dry/logger/formatters/structured"
+
+module Dry
+  module Logger
+    module Formatters
+      # Special handling of `:params` in the log entry payload
+      #
+      # @since 1.0.0
+      # @api private
+      #
+      # @see String
+      class Params < String
+        # @since 1.0.0
+        # @api private
+        def format_entry(entry)
+          if entry.key?(:params)
+            entry[:params]
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -20,10 +20,6 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        NEW_LINE = $/
-
-        # @since 1.0.0
-        # @api private
         HASH_SEPARATOR = ","
 
         # @since 1.0.0

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require "logger"
-
-# we need it for iso8601 method
-require "time"
-
-require "dry/logger/filter"
+require "dry/logger/formatters/structured"
 
 module Dry
   module Logger
@@ -18,7 +13,7 @@ module Dry
       # @api private
       #
       # @see http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger/Formatter.html
-      class String < ::Logger::Formatter
+      class String < Structured
         # @since 1.0.0
         # @api private
         SEPARATOR = " "
@@ -41,34 +36,13 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        DEFAULT_FILTERS = [].freeze
-
-        # @since 1.0.0
-        # @api private
-        NOOP_FILTER = -> message { message }
-
-        # @since 1.0.0
-        # @api private
-        attr_reader :filter
-
-        # @since 1.0.0
-        # @api private
         attr_reader :template
 
         # @since 1.0.0
         # @api private
-        def initialize(filters: DEFAULT_FILTERS, template: DEFAULT_TEMPLATE, **)
-          super()
-          @filter = filters.equal?(DEFAULT_FILTERS) ? NOOP_FILTER : Filter.new(filters)
+        def initialize(template: DEFAULT_TEMPLATE, **options)
+          super(**options)
           @template = template
-        end
-
-        # @since 1.0.0
-        # @api private
-        #
-        # @see http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger/Formatter.html#method-i-call
-        def call(_severity, _time, _progname, entry)
-          format(entry.filter(filter))
         end
 
         private

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -54,10 +54,6 @@ module Dry
         def format_entry(entry)
           if entry.exception?
             format_exception(entry)
-          # TODO: this should not be here. params is a very web-centric concept and should have its
-          #       own formatter
-          elsif entry.params?
-            entry[:params]
           # TODO: there's no scenario for messages AND payload in specs yet
           elsif entry.message
             entry.message

--- a/lib/dry/logger/formatters/structured.rb
+++ b/lib/dry/logger/formatters/structured.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "logger"
+require "dry/logger/filter"
+
+module Dry
+  module Logger
+    module Formatters
+      # Dry::Logger default formatter.
+      # This formatter returns string in key=value format.
+      # Originaly copied from hanami/utils (see Hanami::Logger)
+      #
+      # @since 1.0.0
+      # @api private
+      #
+      # @see http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger/Formatter.html
+      class Structured < ::Logger::Formatter
+        # @since 1.0.0
+        # @api private
+        DEFAULT_FILTERS = [].freeze
+
+        # @since 1.0.0
+        # @api private
+        NOOP_FILTER = -> message { message }
+
+        # @since 1.0.0
+        # @api private
+        attr_reader :filter
+
+        # @since 1.0.0
+        # @api private
+        attr_reader :options
+
+        # @since 1.0.0
+        # @api private
+        def initialize(filters: DEFAULT_FILTERS, **options)
+          super()
+          @filter = filters.equal?(DEFAULT_FILTERS) ? NOOP_FILTER : Filter.new(filters)
+          @options = options
+        end
+
+        # Filter and then format the log entry into a string
+        #
+        # Custom formatters typically won't have to override this method because
+        # the actual formatting logic is implemented as Structured#format
+        #
+        # @see http://www.ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger/Formatter.html#method-i-call
+        #
+        # @since 1.0.0
+        # @return [String]
+        # @api public
+        def call(_severity, _time, _progname, entry)
+          format(entry.filter(filter))
+        end
+
+        # Format entry into a loggable object
+        #
+        # Custom formatters should override this method
+        #
+        # @api since 1.0.0
+        # @return [Entry]
+        # @api public
+        def format(entry)
+          entry
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/logger/formatters/structured.rb
+++ b/lib/dry/logger/formatters/structured.rb
@@ -25,7 +25,7 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        NEW_LINE = $/
+        NEW_LINE = $/ # rubocop:disable Style/SpecialGlobalVars
 
         # @since 1.0.0
         # @api private

--- a/lib/dry/logger/formatters/structured.rb
+++ b/lib/dry/logger/formatters/structured.rb
@@ -25,6 +25,10 @@ module Dry
 
         # @since 1.0.0
         # @api private
+        NEW_LINE = $/
+
+        # @since 1.0.0
+        # @api private
         attr_reader :filter
 
         # @since 1.0.0

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dry/logger/dispatcher"
 
 RSpec.describe Dry::Logger::Dispatcher do

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -175,12 +175,15 @@ RSpec.describe "Dry.Logger" do
         Dry.Logger(:test, formatter: :json).info("foo")
       end
 
-      expect(JSON.parse(output)).to eql(
+      expected_json = {
         "progname" => "test",
         "severity" => "INFO",
         "time" => "2017-01-15T15:00:23Z",
         "message" => "foo"
-      )
+      }
+
+      expect(output).to eql("#{JSON.dump(expected_json)}\n")
+      expect(JSON.parse(output)).to eql(expected_json)
     end
 
     it "has JSON format for string messages" do

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -286,20 +286,20 @@ RSpec.describe "Dry.Logger" do
     let(:filters) { %w[password password_confirmation credit_card user.login] }
 
     let(:params) do
-      Hash[
-        params: Hash[
+      {
+        params: {
           "password" => "password",
           "password_confirmation" => "password",
-          "credit_card" => Hash[
+          "credit_card" => {
             "number" => "4545 4545 4545 4545",
             "name" => "John Citizen"
-          ],
-          "user" => Hash[
+          },
+          "user" => {
             "login" => "John",
             "name" => "John"
-          ]
-        ]
-      ]
+          }
+        }
+      }
     end
 
     subject(:logger) do
@@ -312,7 +312,18 @@ RSpec.describe "Dry.Logger" do
     end
 
     it "filters values for keys in the filters array" do
-      expected = %s({"password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "credit_card"=>{"number"=>"[FILTERED]", "name"=>"[FILTERED]"}, "user"=>{"login"=>"[FILTERED]", "name"=>"John"}})
+      expected = {
+        "password" => "[FILTERED]",
+        "password_confirmation" => "[FILTERED]",
+        "credit_card" => {
+          "number" => "[FILTERED]",
+          "name" => "[FILTERED]"
+        },
+        "user" => {
+          "login" => "[FILTERED]",
+          "name" => "John"
+        }
+      }
 
       output = with_captured_stdout do
         logger.info(params)

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "Dry.Logger" do
     end
   end
 
-  describe "with filters" do
+  describe "with filters and params" do
     let(:filters) { %w[password password_confirmation credit_card user.login] }
 
     let(:params) do
@@ -305,7 +305,7 @@ RSpec.describe "Dry.Logger" do
     subject(:logger) do
       Dry.Logger(
         :test,
-        formatter: :string,
+        formatter: :params,
         template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s",
         filters: filters
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,6 @@ end
 
 require "dry/logger"
 
-require "pathname"
-Dir.glob(Pathname.new(__dir__).join("support", "**", "*.rb")).each do |file|
+Dir.glob(Pathname.new(__dir__).join("support", "**", "*.rb")).sort.each do |file|
   require_relative file
 end


### PR DESCRIPTION
In preparation for 1.0.0.rc1:

- [x] Introduce `Logger::Entry` that is built before dispatching to backends
- [x] Clean-up formatters
- [x] Introduce `Logger::Formatters::Structured` as the main abstract one
- [x] Figure out what to do with special handling of `:params` in entry payloads - this is a left-over from hanami logger and it's a web-centric logging feature. ~I'd say we should have a dedicated web formatter in Hanami instead~ - ended up extracting a custom formatter for it
- [x] Figure out if we want UTC timestamps by default - currently only JSON formatter enforces that and I'm not sure if this is OK. It should be most likely configurable.
- [x] ~Figure out if we want to support Ruby 2.7~ since Hanami 2.0 is >= 3.0 so is dry-logger