### PR TITLE
Conditional dispatch

### DIFF
--- a/lib/dry/logger/backends/stream.rb
+++ b/lib/dry/logger/backends/stream.rb
@@ -17,16 +17,29 @@ module Dry
         attr_reader :level
 
         # @since 0.1.0
+        # @api public
+        attr_accessor :log_if
+
+        # @since 0.1.0
         # @api private
-        def initialize(stream:, formatter:, level: DEFAULT_LEVEL, progname: nil)
+        def initialize(stream:, formatter:, level: DEFAULT_LEVEL, progname: nil, log_if: nil)
           super(stream, progname: progname)
 
           @stream = stream
           @level = LEVELS[level]
 
+          self.log_if = log_if
           self.formatter = formatter
+        end
 
-          freeze
+        # @since 1.0.0
+        # @api private
+        def log?(entry)
+          if log_if
+            log_if.call(entry)
+          else
+            true
+          end
         end
       end
     end

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -118,6 +118,8 @@ module Dry
 
           each_backend { |backend| backend.__send__(severity, entry) if backend.log?(entry) }
         end
+
+        true
       end
 
       # Add a new backend to an existing dispatcher

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -28,6 +28,10 @@ module Dry
 
       # @since 1.0.0
       # @api public
+      attr_reader :level
+
+      # @since 1.0.0
+      # @api public
       attr_reader :time
 
       # @since 1.0.0
@@ -44,6 +48,7 @@ module Dry
       def initialize(progname:, severity:, time: Time.now, message: nil, payload: EMPTY_PAYLOAD)
         @progname = progname
         @severity = severity.to_s.upcase # TODO: this doesn't feel right
+        @level = LEVELS.fetch(severity.to_s)
         @time = time
         @message = message
         @payload = build_payload(payload)
@@ -59,6 +64,36 @@ module Dry
       # @api public
       def [](name)
         payload[name]
+      end
+
+      # @since 1.0.0
+      # @api public
+      def debug?
+        level.equal?(DEBUG)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def info?
+        level.equal?(INFO)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def warn?
+        level.equal?(WARN)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def error?
+        level.equal?(ERROR)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def fatal?
+        level.equal?(FATAL)
       end
 
       # @since 1.0.0

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -3,14 +3,32 @@
 require "dry/logger/dispatcher"
 
 RSpec.describe Dry::Logger::Dispatcher do
+  include_context "stream"
+
   describe "#add_backend" do
-    subject(:logger) { Dry.Logger(:test) }
+    subject(:logger) { Dry.Logger(:test, stream: stream) }
 
     it "adds a new backend" do
       logger.add_backend(stream: SPEC_ROOT.join("../log/test.log"))
 
       expect(logger.backends.size).to be(2)
       expect(logger.backends.last).to be_instance_of(Dry::Logger::Backends::File)
+    end
+
+    it "adds a new backend with conditional dispatch" do
+      logger
+        .add_backend(formatter: :string, template: "first: %<message>s") { |backend|
+          backend.log_if = -> entry { entry.info? }
+        }
+        .add_backend(formatter: :string, template: "second: %<message>s")
+
+      logger.info("hello")
+      logger.warn("world")
+
+      expect(stream).to include("first: hello")
+      expect(stream).to_not include("first: world")
+
+      expect(stream).to include("second: world")
     end
   end
 

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Dry::Logger::Dispatcher do
     end
   end
 
+  describe "#log" do
+    subject(:logger) { Dry.Logger(:test, stream: stream) }
+
+    it "logs and returns true" do
+      expect(logger.info("Hello World")).to be(true)
+    end
+  end
+
   describe "#close" do
     subject(:logger) { Dry.Logger(:test) }
 

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe "Dry.Logger" do
         [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
         2017-01-15 16:00:23 +0100 #{expected}
       LOG
-      )
+                          )
     end
   end
 

--- a/spec/shared/stream.rb
+++ b/spec/shared/stream.rb
@@ -1,0 +1,13 @@
+RSpec.shared_context "stream" do
+  let(:stream) do
+    Class.new(StringIO) do
+      def logged_lines
+        string.split("\n")
+      end
+
+      def include?(log)
+        logged_lines.include?(log)
+      end
+    end.new
+  end
+end

--- a/spec/shared/stream.rb
+++ b/spec/shared/stream.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_context "stream" do
   let(:stream) do
     Class.new(StringIO) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,3 +46,7 @@ require "dry/logger"
 Dir.glob(Pathname.new(__dir__).join("support", "**", "*.rb")).sort.each do |file|
   require_relative file
 end
+
+Dir.glob(Pathname.new(__dir__).join("shared", "**", "*.rb")).sort.each do |file|
+  require_relative file
+end


### PR DESCRIPTION
You can now configure `log_if` on a per-backend basis. This is a simple
function that receives a log entry object and it's meant to return
either true or false.

You can use it like that:

```ruby
logger = Dry.Logger(:test)
  .add_backend(formatter: :string) { |backend|
    backend.log_if = -> entry { entry.info? }
  }.
  .add_backend(formatter: :string) { |backend|
    backend.log_if = -> entry { entry.error? }
  }
```

In this case the first backend will be used only for info logs, and the
second one will be used only for error logs.