### PR TITLE
Add support for shared context and tagged log entries

### DIFF
--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -71,4 +71,32 @@ RSpec.describe Dry::Logger::Dispatcher do
       expect(backend_two).to have_received(:close)
     end
   end
+
+  describe "#tagged" do
+    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s", context: {}) }
+
+    it "sets tags in log entries" do
+      logger.tagged(:metrics) do
+        logger.info("test 1")
+        logger.info("test 2")
+      end
+
+      expect(stream).to include("test 1 tag=:metrics")
+      expect(stream).to include("test 2 tag=:metrics")
+    end
+  end
+
+  describe "#context" do
+    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s", context: {}) }
+
+    it "allows set pre-defined payload data" do
+      logger.context[:component] = "test"
+
+      logger.info("test 1")
+      logger.info("test 2")
+
+      expect(stream).to include('test 1 component="test"')
+      expect(stream).to include('test 2 component="test"')
+    end
+  end
 end


### PR DESCRIPTION
This adds support for setting arbitrary context data that's shared across all backends while logging and also tagged log entries:

```ruby
irb(main):002:0> logger = Dry.Logger(:my_app)
=> 
#<Dry::Logger::Dispatcher:0x0000000106ae9b40
...
irb(main):003:0> logger.context[:component] = "test"
=> "test"
irb(main):004:0> logger.info "hello"
hello component="test"

irb(main):005:0> logger.tagged("red") { logger.warn("oops") }
oops component="test",tag="red"
```