### PR TITLE
Improve exception logging in rack

### DIFF
--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -152,5 +152,10 @@ module Dry
     register_formatter(:json, Formatters::JSON)
 
     register_template(:default, "%<message>s")
+
+    register_template(:rack, <<~STR)
+      [%<progname>s] [%<severity>s] [%<time>s] \
+      %<verb>s %<status>s %<elapsed>s %<ip>s %<path>s %<length>s %<params>s
+    STR
   end
 end

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -20,7 +20,7 @@ module Dry
 
       # @since 1.0.0
       # @api private
-      EXCEPTION_PAYLOAD_KEYS = %i[error message backtrace]
+      EXCEPTION_PAYLOAD_KEYS = %i[error message backtrace].freeze
 
       # @since 1.0.0
       # @api public

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -19,6 +19,10 @@ module Dry
       EMPTY_BACKTRACE = [].freeze
 
       # @since 1.0.0
+      # @api private
+      EXCEPTION_PAYLOAD_KEYS = %i[error message backtrace]
+
+      # @since 1.0.0
       # @api public
       attr_reader :progname
 

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -20,7 +20,7 @@ module Dry
 
       # @since 1.0.0
       # @api private
-      EXCEPTION_PAYLOAD_KEYS = %i[error message backtrace].freeze
+      EXCEPTION_PAYLOAD_KEYS = %i[exception message backtrace].freeze
 
       # @since 1.0.0
       # @api public
@@ -150,9 +150,9 @@ module Dry
       # @api private
       def build_payload(payload)
         if exception?
-          {message: exception.message,
+          {exception: exception.class,
+           message: exception.message,
            backtrace: exception.backtrace || EMPTY_BACKTRACE,
-           error: exception.class,
            **payload}
         else
           payload

--- a/lib/dry/logger/formatters/rack.rb
+++ b/lib/dry/logger/formatters/rack.rb
@@ -16,10 +16,19 @@ module Dry
         # @api private
         def format_entry(entry)
           if entry.exception?
-            super
+            [
+              format_payload(entry, Entry::EXCEPTION_PAYLOAD_KEYS),
+              format_exception(entry)
+            ].reject(&:empty?).join(SEPARATOR)
           else
-            [*entry.payload.except(:params).values, entry[:params]].compact.join(SEPARATOR)
+            format_payload(entry)
           end
+        end
+
+        # @since 1.0.0
+        # @api private
+        def format_payload(entry, excluded_keys = [])
+          [*entry.payload.except(:params, *excluded_keys).values, entry[:params]].compact.join(SEPARATOR)
         end
       end
     end

--- a/lib/dry/logger/formatters/rack.rb
+++ b/lib/dry/logger/formatters/rack.rb
@@ -28,7 +28,10 @@ module Dry
         # @since 1.0.0
         # @api private
         def format_payload(entry, excluded_keys = [])
-          [*entry.payload.except(:params, *excluded_keys).values, entry[:params]].compact.join(SEPARATOR)
+          [
+            *entry.payload.except(:params, *excluded_keys).values,
+            entry[:params]
+          ].compact.join(SEPARATOR)
         end
       end
     end

--- a/lib/dry/logger/formatters/rack.rb
+++ b/lib/dry/logger/formatters/rack.rb
@@ -15,7 +15,11 @@ module Dry
         # @since 1.0.0
         # @api private
         def format_entry(entry)
-          [*entry.payload.except(:params).values, entry[:params]].compact.join(SEPARATOR)
+          if entry.exception?
+            super
+          else
+            [*entry.payload.except(:params).values, entry[:params]].compact.join(SEPARATOR)
+          end
         end
       end
     end

--- a/lib/dry/logger/formatters/rack.rb
+++ b/lib/dry/logger/formatters/rack.rb
@@ -12,26 +12,12 @@ module Dry
       #
       # @see String
       class Rack < String
+        # @see String#initialize
         # @since 1.0.0
         # @api private
-        def format_entry(entry)
-          if entry.exception?
-            [
-              format_payload(entry, Entry::EXCEPTION_PAYLOAD_KEYS),
-              format_exception(entry)
-            ].reject(&:empty?).join(SEPARATOR)
-          else
-            format_payload(entry)
-          end
-        end
-
-        # @since 1.0.0
-        # @api private
-        def format_payload(entry, excluded_keys = [])
-          [
-            *entry.payload.except(:params, *excluded_keys).values,
-            entry[:params]
-          ].compact.join(SEPARATOR)
+        def initialize(**options)
+          super
+          @template = Template[Logger.templates[:rack]]
         end
       end
     end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -21,6 +21,10 @@ module Dry
 
         # @since 1.0.0
         # @api private
+        TAB = SEPARATOR * 2
+
+        # @since 1.0.0
+        # @api private
         HASH_SEPARATOR = ","
 
         # @since 1.0.0
@@ -74,7 +78,9 @@ module Dry
         def format_exception(entry)
           hash = entry.payload
           message = hash.values_at(:error, :message).compact.join(EXCEPTION_SEPARATOR)
-          "#{message}#{NEW_LINE}#{hash[:backtrace].map { |line| "from #{line}" }.join(NEW_LINE)}"
+          backtrace = hash[:backtrace].map { |line, idx| "#{TAB}#{line}" }.join(NEW_LINE)
+
+          "#{message}#{NEW_LINE}#{backtrace}"
         end
 
         # @since 1.0.0

--- a/spec/dry/logger/formatters/json_spec.rb
+++ b/spec/dry/logger/formatters/json_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Dry::Logger::Formatters::JSON do
       "time" => "2017-01-15T15:00:23Z",
       "message" => "foo",
       "backtrace" => [],
-      "error" => "Exception"
+      "exception" => "Exception"
     )
   end
 

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Dry::Logger::Formatters::Rack do
         from file-1.rb:312
         from file-2.rb:12
         from file-3.rb:115
-        STR
+      STR
 
       expect(output).to eql(expected)
     end
@@ -108,7 +108,7 @@ RSpec.describe Dry::Logger::Formatters::Rack do
         from file-1.rb:312
         from file-2.rb:12
         from file-3.rb:115
-        STR
+      STR
 
       expect(output).to eql(expected)
     end

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -92,5 +92,25 @@ RSpec.describe Dry::Logger::Formatters::Rack do
 
       expect(output).to eql(expected)
     end
+
+    it "logs exception details with a backtrace and additional payload" do
+      backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
+      exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
+
+      payload = {verb: "POST", status: 500, elapsed: "2ms", ip: "127.0.0.1", path: "/api/users"}
+
+      output = with_captured_stdout do
+        logger.error(exception, **payload)
+      end
+
+      expected = <<~STR
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] POST 500 2ms 127.0.0.1 /api/users StandardError: foo
+        from file-1.rb:312
+        from file-2.rb:12
+        from file-3.rb:115
+        STR
+
+      expect(output).to eql(expected)
+    end
   end
 end

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -73,4 +73,24 @@ RSpec.describe Dry::Logger::Formatters::Rack do
       LOG
     end
   end
+
+  context "with an exception" do
+    it "logs exception details with a backtrace" do
+      backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
+      exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
+
+      output = with_captured_stdout do
+        logger.error(exception)
+      end
+
+      expected = <<~STR
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo
+        from file-1.rb:312
+        from file-2.rb:12
+        from file-3.rb:115
+        STR
+
+      expect(output).to eql(expected)
+    end
+  end
 end

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -42,15 +42,15 @@ RSpec.describe Dry::Logger::Formatters::Rack do
 
   let(:filtered_params) do
     {"password" => "[FILTERED]",
-    "password_confirmation" => "[FILTERED]",
-    "credit_card" => {
-      "number" => "[FILTERED]",
-      "name" => "[FILTERED]"
-    },
-    "user" => {
-      "login" => "[FILTERED]",
-      "name" => "John"
-    }}
+     "password_confirmation" => "[FILTERED]",
+     "credit_card" => {
+       "number" => "[FILTERED]",
+       "name" => "[FILTERED]"
+     },
+     "user" => {
+       "login" => "[FILTERED]",
+       "name" => "John"
+     }}
   end
 
   context "with filters" do

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Logger::Formatters::Rack do
+  include_context "stream"
+
   subject(:logger) do
-    Dry.Logger(
-      :test,
-      formatter: :rack,
-      template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s",
-      filters: filters
-    )
+    Dry.Logger(:test, stream: stream, formatter: :rack, filters: filters)
   end
 
   before do
@@ -15,7 +12,7 @@ RSpec.describe Dry::Logger::Formatters::Rack do
   end
 
   let(:filters) do
-    []
+    %w[password password_confirmation credit_card user.login]
   end
 
   let(:params) do
@@ -40,75 +37,46 @@ RSpec.describe Dry::Logger::Formatters::Rack do
      ip: "127.0.0.1",
      path: "/api/users",
      length: 312,
-     params: params,
-     time: Time.now}
+     params: params}
+  end
+
+  let(:filtered_params) do
+    {"password" => "[FILTERED]",
+    "password_confirmation" => "[FILTERED]",
+    "credit_card" => {
+      "number" => "[FILTERED]",
+      "name" => "[FILTERED]"
+    },
+    "user" => {
+      "login" => "[FILTERED]",
+      "name" => "John"
+    }}
   end
 
   context "with filters" do
-    let(:filters) do
-      %w[password password_confirmation credit_card user.login]
-    end
-
     it "filters values for keys in the filters array" do
-      expected = {
-        "password" => "[FILTERED]",
-        "password_confirmation" => "[FILTERED]",
-        "credit_card" => {
-          "number" => "[FILTERED]",
-          "name" => "[FILTERED]"
-        },
-        "user" => {
-          "login" => "[FILTERED]",
-          "name" => "John"
-        }
-      }
+      logger.info(payload)
 
-      output = with_captured_stdout do
-        logger.info(payload)
-      end
-
-      expect(output).to eq(<<~LOG)
+      expect(output).to eql(<<~LOG.strip)
         [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
-        2017-01-15 16:00:23 +0100 #{expected}
+        #{filtered_params}
       LOG
     end
   end
 
   context "with an exception" do
-    it "logs exception details with a backtrace" do
-      backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
-      exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
-
-      output = with_captured_stdout do
-        logger.error(exception)
-      end
-
-      expected = <<~STR
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo
-        from file-1.rb:312
-        from file-2.rb:12
-        from file-3.rb:115
-      STR
-
-      expect(output).to eql(expected)
-    end
-
     it "logs exception details with a backtrace and additional payload" do
       backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
       exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
 
-      payload = {verb: "POST", status: 500, elapsed: "2ms", ip: "127.0.0.1", path: "/api/users"}
+      logger.error(exception, **payload)
 
-      output = with_captured_stdout do
-        logger.error(exception, **payload)
-      end
-
-      expected = <<~STR
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] POST 500 2ms 127.0.0.1 /api/users StandardError: foo
-        from file-1.rb:312
-        from file-2.rb:12
-        from file-3.rb:115
-      STR
+      expected = <<~LOG.strip
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
+        #{filtered_params} \
+        exception=StandardError message="foo" \
+        backtrace=["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
+      LOG
 
       expect(output).to eql(expected)
     end

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Dry::Logger::Formatters::Rack do
     allow(Time).to receive(:now).and_return(DateTime.parse("2017-01-15 16:00:23 +0100").to_time)
   end
 
-  let(:filters) { %w[password password_confirmation credit_card user.login] }
+  let(:filters) do
+    []
+  end
 
   let(:params) do
     {
@@ -42,27 +44,33 @@ RSpec.describe Dry::Logger::Formatters::Rack do
      time: Time.now}
   end
 
-  it "filters values for keys in the filters array" do
-    expected = {
-      "password" => "[FILTERED]",
-      "password_confirmation" => "[FILTERED]",
-      "credit_card" => {
-        "number" => "[FILTERED]",
-        "name" => "[FILTERED]"
-      },
-      "user" => {
-        "login" => "[FILTERED]",
-        "name" => "John"
-      }
-    }
-
-    output = with_captured_stdout do
-      logger.info(payload)
+  context "with filters" do
+    let(:filters) do
+      %w[password password_confirmation credit_card user.login]
     end
 
-    expect(output).to eq(<<~LOG)
-      [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
-      2017-01-15 16:00:23 +0100 #{expected}
-    LOG
+    it "filters values for keys in the filters array" do
+      expected = {
+        "password" => "[FILTERED]",
+        "password_confirmation" => "[FILTERED]",
+        "credit_card" => {
+          "number" => "[FILTERED]",
+          "name" => "[FILTERED]"
+        },
+        "user" => {
+          "login" => "[FILTERED]",
+          "name" => "John"
+        }
+      }
+
+      output = with_captured_stdout do
+        logger.info(payload)
+      end
+
+      expect(output).to eq(<<~LOG)
+        [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
+        2017-01-15 16:00:23 +0100 #{expected}
+      LOG
+    end
   end
 end

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dry::Logger::Formatters::String do
       logger.error(exception)
 
       expected = <<~STR
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] exception=StandardError message="foo"
           file-1.rb:312
           file-2.rb:12
           file-3.rb:115

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Dry::Logger::Formatters::String do
 
       expected = <<~STR
         [test] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo
-        from file-1.rb:312
-        from file-2.rb:12
-        from file-3.rb:115
+          file-1.rb:312
+          file-2.rb:12
+          file-3.rb:115
       STR
 
       expect(output).to eql(expected)


### PR DESCRIPTION
This tweaks rack formatter to simply rely on a template rather than having complex formatting logic. A side-effect of this is that exceptions are now just dumped using standard formatting and I think there's nothing wrong with that.

Here's an example:

```
[test] [ERROR] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 {"password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]", "credit_card"=>{"number"=>"[FILTERED]", "name"=>"[FILTERED]"}, "user"=>{"login"=>"[FILTERED]", "name"=>"John"}} exception=StandardError message="foo" backtrace=["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
```

I'm going to add a dedicated string exception formatter because exceptions should be logged by something dedicated.