### PR TITLE
Better templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,9 @@ Metrics/CyclomaticComplexity:
   Enabled: true
   Max: 12
 
+Style/MapToHash:
+  Enabled: false
+
 Style/ExponentialNotation:
   Enabled: false
 

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -69,12 +69,30 @@ module Dry
       formatters
     end
 
+    # Register a new template
+    #
+    # @example
+    #   Dry::Logger.register_template(:request, "[%<severity>s] %<verb>s %<path>s")
+    #
+    #   logger = Dry.Logger(:my_app, template: :request)
+    #
+    #   logger.info(verb: "GET", path: "/users")
+    #   # [INFO] GET /users
+    #
+    # @since 1.0.0
+    # @return [Hash]
+    # @api public
+    def self.register_template(name, template)
+      templates[name] = template
+      templates
+    end
+
     # Build a logging backend instance
     #
     # @since 1.0.0
     # @return [Backends::Stream]
     # @api private
-    def self.new(stream: $stdout, **opts)
+    def self.new(stream: $stdout, **options)
       backend =
         case stream
         when IO, StringIO then Backends::IO
@@ -83,21 +101,34 @@ module Dry
           raise ArgumentError, "unsupported stream type #{stream.class}"
         end
 
-      formatter_opt = opts[:formatter]
+      formatter_spec = options[:formatter]
+      template_spec = options[:template]
 
-      formatter =
-        case formatter_opt
-        when Symbol then formatters.fetch(formatter_opt).new(**opts)
-        when Class then formatter_opt.new(**opts)
-        when NilClass then formatters[:string].new(**opts)
-        when ::Logger::Formatter then formatter_opt
+      template =
+        case template_spec
+        when Symbol then templates.fetch(template_spec)
+        when String then template_spec
+        when nil then templates[:default]
         else
-          raise ArgumentError, "unsupported formatter option #{formatter_opt.inspect}"
+          raise ArgumentError,
+                ":template option must be a Symbol or a String (`#{template_spec}` given)"
         end
 
-      backend_opts = opts.select { |key, _| BACKEND_OPT_KEYS.include?(key) }
+      formatter_options = {**options, template: template}
 
-      backend.new(stream: stream, **backend_opts, formatter: formatter)
+      formatter =
+        case formatter_spec
+        when Symbol then formatters.fetch(formatter_spec).new(**formatter_options)
+        when Class then formatter_spec.new(**formatter_options)
+        when nil then formatters[:string].new(**formatter_options)
+        when ::Logger::Formatter then formatter_spec
+        else
+          raise ArgumentError, "Unsupported formatter option #{formatter_spec.inspect}"
+        end
+
+      backend_options = options.select { |key, _| BACKEND_OPT_KEYS.include?(key) }
+
+      backend.new(stream: stream, **backend_options, formatter: formatter)
     end
 
     # Internal formatters registry
@@ -108,8 +139,18 @@ module Dry
       @formatters ||= {}
     end
 
+    # Internal templates registry
+    #
+    # @since 1.0.0
+    # @api private
+    def self.templates
+      @templates ||= {}
+    end
+
     register_formatter(:string, Formatters::String)
     register_formatter(:rack, Formatters::Rack)
     register_formatter(:json, Formatters::JSON)
+
+    register_template(:default, "%<message>s")
   end
 end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -29,15 +29,11 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        DEFAULT_TEMPLATE = "%<message>s"
-
-        # @since 1.0.0
-        # @api private
         attr_reader :template
 
         # @since 1.0.0
         # @api private
-        def initialize(template: DEFAULT_TEMPLATE, **options)
+        def initialize(template: Logger.templates[:default], **options)
           super(**options)
           @template = Template[template]
         end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -47,7 +47,7 @@ module Dry
             "#{template % entry.meta.merge(message: format_entry(entry))}#{NEW_LINE}"
           else
             [
-              template % entry.to_h,
+              template % format_payload_values(entry),
               format_payload(entry.payload.except(*template.tokens))
             ].reject(&:empty?).join(SEPARATOR)
           end
@@ -81,6 +81,17 @@ module Dry
         # @api private
         def format_payload(entry)
           entry.map { |key, value| "#{key}=#{value.inspect}" }.join(HASH_SEPARATOR)
+        end
+
+        # @since 1.0.0
+        # @api private
+        def format_payload_values(entry)
+          entry
+            .to_h
+            .map { |key, value|
+              [key, respond_to?(meth = "format_#{key}") ? __send__(meth, value) : value]
+            }
+            .to_h
         end
       end
     end

--- a/lib/dry/logger/formatters/template.rb
+++ b/lib/dry/logger/formatters/template.rb
@@ -14,7 +14,7 @@ module Dry
       class Template
         # @since 1.0.0
         # @api private
-        TOKEN_REGEXP = %r[%<(\w*)>s].freeze
+        TOKEN_REGEXP = /%<(\w*)>s/.freeze
 
         # @since 1.0.0
         # @api private

--- a/lib/dry/logger/formatters/template.rb
+++ b/lib/dry/logger/formatters/template.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Dry
+  module Logger
+    module Formatters
+      # Basic string formatter.
+      #
+      # This formatter returns log entries in key=value format.
+      #
+      # @since 1.0.0
+      # @api public
+      class Template
+        # @since 1.0.0
+        # @api private
+        TOKEN_REGEXP = %r[%<(\w*)>s].freeze
+
+        # @since 1.0.0
+        # @api private
+        MESSAGE_TOKEN = "%<message>s"
+
+        # @since 1.0.0
+        # @api private
+        attr_reader :value
+
+        # @since 1.0.0
+        # @api private
+        attr_reader :tokens
+
+        # @since 1.0.0
+        # @api private
+        def self.[](value)
+          cache.fetch(value) { cache[value] = Template.new(value) }
+        end
+
+        # @since 1.0.0
+        # @api private
+        private_class_method def self.cache
+          @cache ||= {}
+        end
+
+        # @since 1.0.0
+        # @api private
+        def initialize(value)
+          @value = value
+          @tokens = value.scan(TOKEN_REGEXP).flatten(1).map(&:to_sym).to_set
+        end
+
+        # @since 1.0.0
+        # @api private
+        def %(tokens)
+          value % tokens
+        end
+
+        # @since 1.0.0
+        # @api private
+        def include?(token)
+          tokens.include?(token)
+        end
+      end
+    end
+  end
+end

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Logger::Formatters::String do
+  include_context "stream"
+
   subject(:logger) do
-    Dry.Logger(:test, template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s")
+    Dry.Logger(:test, stream: stream, template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s")
   end
 
   before do
@@ -11,17 +13,13 @@ RSpec.describe Dry::Logger::Formatters::String do
 
   describe "using customized template" do
     it "when passed as a symbol, it has key=value format for string messages" do
-      output = with_captured_stdout do
-        logger.info("foo")
-      end
+      logger.info("foo")
 
       expect(output).to eq "[test] [INFO] [2017-01-15 16:00:23 +0100] foo\n"
     end
 
     it "has key=value format for hash messages" do
-      output = with_captured_stdout do
-        logger.info(foo: "bar")
-      end
+      logger.info(foo: "bar")
 
       expect(output).to eq %([test] [INFO] [2017-01-15 16:00:23 +0100] foo="bar"\n)
     end
@@ -30,9 +28,7 @@ RSpec.describe Dry::Logger::Formatters::String do
       backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
       exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
 
-      output = with_captured_stdout do
-        logger.error(exception)
-      end
+      logger.error(exception)
 
       expected = <<~STR
         [test] [ERROR] [2017-01-15 16:00:23 +0100] StandardError: foo

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe Dry::Logger::Formatters::String do
   include_context "stream"
 
   subject(:logger) do
-    Dry.Logger(:test, stream: stream, template: "[%<progname>s] [%<severity>s] [%<time>s] %<message>s")
+    Dry.Logger(:test, stream: stream, template: template)
   end
 
   before do
     allow(Time).to receive(:now).and_return(DateTime.parse("2017-01-15 16:00:23 +0100").to_time)
   end
 
-  describe "using customized template" do
+  describe "using customized template with `message` token" do
+    let(:template) do
+      "[%<progname>s] [%<severity>s] [%<time>s] %<message>s"
+    end
+
     it "when passed as a symbol, it has key=value format for string messages" do
       logger.info("foo")
 
@@ -38,6 +42,24 @@ RSpec.describe Dry::Logger::Formatters::String do
         STR
 
       expect(output).to eql(expected)
+    end
+  end
+
+  describe "using customized template with payload keys as tokens" do
+    let(:template) do
+      "[%<severity>s] %<verb>s %<path>s"
+    end
+
+    it "replaces tokens with payload values" do
+      logger.info verb: "POST", path: "/users"
+
+      expect(output).to eql("[INFO] POST /users")
+    end
+
+    it "replaces tokens with payload values and dumps payload's remainder" do
+      logger.info verb: "POST", path: "/users", foo: "bar"
+
+      expect(output).to eql(%([INFO] POST /users foo="bar"))
     end
   end
 end

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dry::Logger::Formatters::String do
         from file-1.rb:312
         from file-2.rb:12
         from file-3.rb:115
-        STR
+      STR
 
       expect(output).to eql(expected)
     end

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe "Dry.Logger" do
     end
   end
 
+  context "registering a custom template" do
+    subject(:logger) { Dry.Logger(:test, template: :details) }
+
+    before do
+      Dry::Logger.register_template(:details, "[%<severity>s] [%<time>s] %<message>s")
+    end
+
+    it "logs to $stdout by default using a registered template" do
+      message = "hello, world"
+
+      output = with_captured_stdout do
+        logger.info(message)
+      end
+
+      expect(output).to eql("[INFO] [2017-01-15 16:00:23 +0100] hello, world\n")
+    end
+  end
+
   context "using external logger as backend" do
     include_context "stream"
 

--- a/spec/shared/stream.rb
+++ b/spec/shared/stream.rb
@@ -16,4 +16,8 @@ RSpec.shared_context "stream" do
       end
     end.new
   end
+
+  let(:output) do
+    stream.string
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,16 @@ end
 Dir.glob(Pathname.new(__dir__).join("shared", "**", "*.rb")).sort.each do |file|
   require_relative file
 end
+
+RSpec.configure do |config|
+  global_registries = %i[formatters templates]
+
+  config.around do |example|
+    reg_state = global_registries.to_h { |reg| [reg, Dry::Logger.__send__(reg)] }
+    example.run
+  ensure
+    reg_state.each do |reg, val|
+      Dry::Logger.instance_variable_set("@#{reg}", val)
+    end
+  end
+end


### PR DESCRIPTION
This adds a global registry for templates:

```ruby
> Dry::Logger.register_template(:details, "[%<severity>s] [%<time>s] %<message>s")
=> {:default=>"%<message>s", :details=>"[%<severity>s] [%<time>s] %<message>s"}

> logger = Dry.Logger(:test, template: :details)
=> #<Dry::Logger::Dispatcher:...>

> logger.info("Hello World!")
[INFO] [2022-11-12 08:05:26 +0100] Hello World!
```

...and support for payload keys in template tokens:

```ruby
> Dry::Logger.register_template(:rack, "[%<severity>s] [%<time>s] %<verb>s %<path>s")
=> {:default=>"%<message>s", :details=>"[%<severity>s] [%<time>s] %<message>s", :rack=>"[%<severity>s] [%<time>s] %<verb>s %<path>s"}

> logger = Dry.Logger(:test, template: :rack)
=> #<Dry::Logger::Dispatcher:...

> logger.info(verb: "GET", path: "/users")
[INFO] [2022-11-12 08:06:59 +0100] GET /users
```

...and support for per-payload key formatting:

```ruby
> logger = Dry.Logger(:test,
  template: :rack,
  formatter: Class.new(Dry::Logger::Formatters::String) {
    def format_verb(v); "WOW:#{v}"; end
  })
=>#<Dry::Logger::Dispatcher:...

> logger.info(verb: "GET", path: "/users")
[INFO] [2022-11-12 08:08:41 +0100] WOW:GET /users
```