### PR TITLE
Add an exception formatter

### DIFF
--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -6,6 +6,7 @@ require "dry/logger/constants"
 require "dry/logger/dispatcher"
 
 require "dry/logger/formatters/string"
+require "dry/logger/formatters/exception"
 require "dry/logger/formatters/rack"
 require "dry/logger/formatters/json"
 
@@ -148,10 +149,16 @@ module Dry
     end
 
     register_formatter(:string, Formatters::String)
+    register_formatter(:exception, Formatters::Exception)
     register_formatter(:rack, Formatters::Rack)
     register_formatter(:json, Formatters::JSON)
 
     register_template(:default, "%<message>s")
+
+    register_template(:exception, <<~STR)
+      [%<progname>s] [%<severity>s] [%<time>s] exception=%<exception>s message=%<message>s
+      %<backtrace>s
+    STR
 
     register_template(:rack, <<~STR)
       [%<progname>s] [%<severity>s] [%<time>s] \

--- a/lib/dry/logger/formatters/exception.rb
+++ b/lib/dry/logger/formatters/exception.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "set"
+
+require_relative "template"
+require_relative "structured"
+
+module Dry
+  module Logger
+    module Formatters
+      # Basic string formatter.
+      #
+      # This formatter returns log entries in key=value format.
+      #
+      # @since 1.0.0
+      # @api public
+      class Exception < String
+        # @see String#initialize
+        # @since 1.0.0
+        # @api private
+        def initialize(**options)
+          super
+          @template = Template[Logger.templates[:exception]]
+        end
+
+        # @since 1.0.0
+        # @api private
+        def format_backtrace(value)
+          value.map { |line| "#{TAB}#{line}" }.join(NEW_LINE)
+        end
+
+        # @since 1.0.0
+        # @api private
+        def format_message(value)
+          value.inspect
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -47,7 +47,7 @@ module Dry
         # @since 1.0.0
         # @api private
         def format(entry)
-          if template.include?(:message)
+          if template.include?(:message) && !entry.exception?
             "#{template % entry.meta.merge(message: format_entry(entry))}#{NEW_LINE}"
           else
             [
@@ -60,9 +60,7 @@ module Dry
         # @since 1.0.0
         # @api private
         def format_entry(entry)
-          if entry.exception?
-            format_exception(entry)
-          elsif entry.message
+          if entry.message
             if entry.payload.empty?
               entry.message
             else
@@ -75,27 +73,8 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        def format_exception(entry)
-          log_line = [
-            format_payload(entry.payload.slice(:exception, :message)),
-            format_payload(entry.payload.except(*Entry::EXCEPTION_PAYLOAD_KEYS))
-          ].reject(&:empty?).join(SEPARATOR)
-
-          trace_line = format_backtrace(entry)
-
-          "#{log_line}#{NEW_LINE}#{trace_line}"
-        end
-
-        # @since 1.0.0
-        # @api private
         def format_payload(entry)
           entry.map { |key, value| "#{key}=#{value.inspect}" }.join(SEPARATOR)
-        end
-
-        # @since 1.0.0
-        # @api private
-        def format_backtrace(entry)
-          entry[:backtrace].map { |line| "#{TAB}#{line}" }.join(NEW_LINE)
         end
 
         # @since 1.0.0

--- a/spec/dry/logger/formatters/exception_spec.rb
+++ b/spec/dry/logger/formatters/exception_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Logger::Formatters::Exception do
+  include_context "stream"
+
+  subject(:logger) do
+    Dry.Logger(:test, stream: stream, formatter: :exception)
+  end
+
+  before do
+    allow(Time).to receive(:now).and_return(DateTime.parse("2017-01-15 16:00:23 +0100").to_time)
+  end
+
+  it "logs exception information and a backtrace" do
+    backtrace = ["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
+    exception = StandardError.new("foo").tap { |e| e.set_backtrace(backtrace) }
+
+    logger.error(exception)
+
+    expected = <<~STR
+      [test] [ERROR] [2017-01-15 16:00:23 +0100] exception=StandardError message="foo"
+        file-1.rb:312
+        file-2.rb:12
+        file-3.rb:115
+    STR
+
+    expect(output).to eql(expected)
+  end
+end

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -39,10 +39,8 @@ RSpec.describe Dry::Logger::Formatters::String do
       logger.error(exception)
 
       expected = <<~STR
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] exception=StandardError message="foo"
-          file-1.rb:312
-          file-2.rb:12
-          file-3.rb:115
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] foo exception=StandardError \
+        backtrace=#{backtrace.inspect}
       STR
 
       expect(output).to eql(expected)


### PR DESCRIPTION
This is a follow up after #11 because a dedicated exception logger is going to be much simpler to manage.

A preferable way of setting it up would be:

```ruby
> logger = Dry.Logger(:app) { |setup|
    setup.add_backend(formatter: :exception) { |backend|
      backend.log_if = :exception?.to_proc
    }
  }
=> #<Dry::Logger::Dispatcher:...

> logger.error(StandardError.new("Oops").tap { |e| e.set_backtrace(["file.rb:1", "file.rb:12"]) })
# [app] [ERROR] [2022-11-12 10:50:59 +0100] exception=StandardError message="Oops"
#  file.rb:1
#  file.rb:12

> logger.info "regular logging"
# regular logging
```

Here's an example from Hanami spec suite that uses this branch:

```
# Logfile created on 2022-11-12 11:02:06 +0100 by logger.rb/v1.5.0
[test_app] [INFO] [2022-11-12 11:02:06 +0100] GET 200 0ms 127.0.0.1 / - {}
[test_app] [ERROR] [2022-11-12 11:02:06 +0100] exception=StandardError message="OH NOEZ"
  /private/var/folders/gr/wm7q1v1917ngd1jy92t0tppm0000gn/T/d20221112-71758-6ooue8/app/actions/users/index.rb:6:in `handle'
  /Users/solnic/Workspace/hanami/controller/lib/hanami/action.rb:339:in `block in call'
  /Users/solnic/Workspace/hanami/controller/lib/hanami/action.rb:320:in `catch'
  /Users/solnic/Workspace/hanami/controller/lib/hanami/action.rb:320:in `call'
  /Users/solnic/Workspace/hanami/hanami/lib/hanami/slice/routing/resolver.rb:78:in `block in resolve_slice_action'
  /Users/solnic/Workspace/hanami/router/lib/hanami/router.rb:106:in `call'
  /Users/solnic/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dry-monitor-1.0.0/lib/dry/monitor/rack/middleware.rb:35:in `block in call'
  /Users/solnic/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dry-monitor-1.0.0/lib/dry/monitor/clock.rb:10:in `measure'
  /Users/solnic/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dry-monitor-1.0.0/lib/dry/monitor/rack/middleware.rb:35:in `call'
  /Users/solnic/Workspace/hanami/router/lib/hanami/middleware/app.rb:40:in `call'
  /Users/solnic/Workspace/hanami/hanami/lib/hanami/slice.rb:758:in `call'
```

One thing I'm wondering though is whether exception log entry coming from a request should include request log payload too (verb, path, ip etc.). WDYT?