### PR TITLE
Support block-based setup

### DIFF
--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -53,6 +53,7 @@ module Dry
       # @api public
       def self.setup(id, **options)
         dispatcher = new(id, **DEFAULT_OPTS, **options)
+        yield(dispatcher) if block_given?
         dispatcher.add_backend if dispatcher.backends.empty?
         dispatcher
       end

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe "Dry.Logger" do
     end
   end
 
+  context "adding backends via block only" do
+    include_context "stream"
+
+    it "doesn't setup the default logger" do
+      logger = Dry.Logger(:test, stream: stream) { |setup|
+        setup.add_backend(formatter: :string, template: "[%<severity>s] %<message>s")
+      }
+
+      expect(logger.backends.size).to be(1)
+
+      logger.info "Hello World!"
+
+      expect(output).to eql("[INFO] Hello World!\n")
+    end
+  end
+
   context "registering a custom template" do
     subject(:logger) { Dry.Logger(:test, template: :details) }
 


### PR DESCRIPTION
This adds support for block-based setup that makes it possible to setup your own backends only and skip the default one:

```ruby
> logger = Dry.Logger(:test) { |setup| setup.add_backend(formatter: :string, template: "LOG: %<message>s") }
=> #<Dry::Logger::Dispatcher:...

> logger.info "hi hello"
# LOG: hi hello
```