### PR TITLE
Refactor exception logging

### DIFF
--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -151,11 +151,12 @@ module Dry
     register_formatter(:rack, Formatters::Rack)
     register_formatter(:json, Formatters::JSON)
 
-    register_template(:default, "%<message>s")
+    register_template(:default, "%<message>s %<payload>s")
 
     register_template(:rack, <<~STR)
       [%<progname>s] [%<severity>s] [%<time>s] \
-      %<verb>s %<status>s %<elapsed>s %<ip>s %<path>s %<length>s %<params>s
+      %<verb>s %<status>s %<elapsed>s %<ip>s %<path>s %<length>s %<payload>s
+        %<params>s
     STR
   end
 end

--- a/lib/dry/logger/constants.rb
+++ b/lib/dry/logger/constants.rb
@@ -4,6 +4,18 @@ require "logger"
 
 module Dry
   module Logger
+    # @since 1.0.0
+    # @api private
+    NEW_LINE = $/ # rubocop:disable Style/SpecialGlobalVars
+
+    # @since 1.0.0
+    # @api private
+    EMPTY_ARRAY = [].freeze
+
+    # @since 1.0.0
+    # @api private
+    EMPTY_HASH = {}.freeze
+
     LOG_METHODS = %i[debug error fatal info warn].freeze
 
     BACKEND_METHODS = %i[close].freeze

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -101,14 +101,12 @@ module Dry
 
           if data[:message]
             data.except(*payload.keys)
+          elsif template.include?(:message)
+            data[:message] = data.delete(:payload)
+            data[:payload] = nil
+            data
           else
-            if template.include?(:message)
-              data[:message] = data.delete(:payload)
-              data[:payload] = nil
-              data
-            else
-              data
-            end
+            data
           end
         end
       end

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -94,7 +94,7 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        def template_data(entry, exclude: [])
+        def template_data(entry, exclude: EMPTY_ARRAY)
           data = format_values(entry)
           payload = data.except(:message, *entry.meta.keys, *template.tokens, *exclude)
           data[:payload] = format_payload(payload)

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -39,7 +39,7 @@ module Dry
         # @api private
         def initialize(template: Logger.templates[:default], **options)
           super(**options)
-          @template = Template[*template]
+          @template = Template[template]
         end
 
         private

--- a/lib/dry/logger/formatters/structured.rb
+++ b/lib/dry/logger/formatters/structured.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "logger"
+
+require "dry/logger/constants"
 require "dry/logger/filter"
 
 module Dry
@@ -20,10 +22,6 @@ module Dry
         # @since 1.0.0
         # @api private
         NOOP_FILTER = -> message { message }
-
-        # @since 1.0.0
-        # @api private
-        NEW_LINE = $/ # rubocop:disable Style/SpecialGlobalVars
 
         # @since 1.0.0
         # @api private

--- a/lib/dry/logger/formatters/template.rb
+++ b/lib/dry/logger/formatters/template.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "set"
+require "dry/logger/constants"
 
 module Dry
   module Logger
@@ -50,7 +51,9 @@ module Dry
         # @since 1.0.0
         # @api private
         def %(tokens)
-          value % tokens
+          output = value % tokens
+          output.strip!
+          output.split(NEW_LINE).map(&:rstrip).join(NEW_LINE)
         end
 
         # @since 1.0.0

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe Dry::Logger::Dispatcher do
   end
 
   describe "#tagged" do
-    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {}) }
+    subject(:logger) do
+      Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {})
+    end
 
     it "sets tags in log entries" do
       logger.tagged(:metrics) do
@@ -109,7 +111,9 @@ RSpec.describe Dry::Logger::Dispatcher do
   end
 
   describe "#context" do
-    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {}) }
+    subject(:logger) do
+      Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {})
+    end
 
     it "allows set pre-defined payload data" do
       logger.context[:component] = "test"

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Dry::Logger::Dispatcher do
   end
 
   describe "#tagged" do
-    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s", context: {}) }
+    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {}) }
 
     it "sets tags in log entries" do
       logger.tagged(:metrics) do
@@ -109,7 +109,7 @@ RSpec.describe Dry::Logger::Dispatcher do
   end
 
   describe "#context" do
-    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s", context: {}) }
+    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<message>s %<payload>s", context: {}) }
 
     it "allows set pre-defined payload data" do
       logger.context[:component] = "test"

--- a/spec/dry/logger/formatters/rack_spec.rb
+++ b/spec/dry/logger/formatters/rack_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Dry::Logger::Formatters::Rack do
       logger.info(payload)
 
       expect(output).to eql(<<~LOG)
-        [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
-        #{filtered_params}
+        [test] [INFO] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312
+          #{filtered_params}
       LOG
     end
   end
@@ -68,10 +68,12 @@ RSpec.describe Dry::Logger::Formatters::Rack do
       logger.error(exception, **payload)
 
       expected = <<~LOG
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312 \
-        #{filtered_params} \
-        exception=StandardError message="foo" \
-        backtrace=["file-1.rb:312", "file-2.rb:12", "file-3.rb:115"]
+        [test] [ERROR] [2017-01-15 16:00:23 +0100] POST 200 2ms 127.0.0.1 /api/users 312
+          #{filtered_params}
+          foo (StandardError)
+          file-1.rb:312
+          file-2.rb:12
+          file-3.rb:115
       LOG
 
       expect(output).to eql(expected)

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dry::Logger::Formatters::String do
 
   describe "using customized template with `message` token" do
     let(:template) do
-      "[%<progname>s] [%<severity>s] [%<time>s] %<message>s"
+      "[%<progname>s] [%<severity>s] [%<time>s] %<message>s %<payload>s"
     end
 
     it "when passed as a symbol, it has key=value format for string messages" do
@@ -35,7 +35,8 @@ RSpec.describe Dry::Logger::Formatters::String do
       logger.error(exception)
 
       expected = <<~STR
-        [test] [ERROR] [2017-01-15 16:00:23 +0100] exception=StandardError message="foo"
+        [test] [ERROR] [2017-01-15 16:00:23 +0100]
+          foo (StandardError)
           file-1.rb:312
           file-2.rb:12
           file-3.rb:115
@@ -47,7 +48,7 @@ RSpec.describe Dry::Logger::Formatters::String do
 
   describe "using customized template with payload keys as tokens" do
     let(:template) do
-      "[%<severity>s] %<verb>s %<path>s"
+      "[%<severity>s] %<verb>s %<path>s %<payload>s"
     end
 
     it "replaces tokens with payload values" do
@@ -73,7 +74,7 @@ RSpec.describe Dry::Logger::Formatters::String do
     end
 
     let(:template) do
-      "[%<severity>s] %<verb>s %<path>s"
+      "[%<severity>s] %<verb>s %<path>s %<payload>s"
     end
 
     it "replaces tokens with payload values using custom formatting methods" do


### PR DESCRIPTION
This refactors how exception are being logged but it's also just a bigger refactoring of how entries and formatting is handled:

- `Entry` now separates exception from message
- `Entry` now dumps exception into a hash *only for JSON logging*
- `String` formatter can now handle cherry-picked payload keys and entire payloads when rendering a template. This means you can specify how specific values from payload should be rendered and if you didn't specify all keys, the remaining keys will be dumped using default `key=value` formatting
- and the actual essence of this change: Exceptions are now appended to a log using the same formatting as when an exception is raised and displayed in the output by Ruby, so ie `oops (StandardError)` followed by a backtrace

Bonus:

- Display `params` on a new line in the rack formatter

# Plain exception

```ruby
irb(main):004:0> logger = Dry.Logger(:test, template: "[%<severity>s] %<message>s")
=> 
#<Dry::Logger::Dispatcher:0x0000000111d98d90
...
irb(main):005:0> logger.error StandardError.new("OH NOEZ").tap { |e| e.set_backtrace(["f1.rb:12", "f2.rb:51"]) }
[ERROR]
  OH NOEZ (StandardError)
  f1.rb:12
  f2.rb:51
```

# Exception with extra payload info

```
irb(main):006:0> logger = Dry.Logger(:test, template: "[%<severity>s] %<message>s %<payload>s")
=> 
#<Dry::Logger::Dispatcher:0x0000000111c9b050
...
irb(main):007:0> logger.error StandardError.new("OH NOEZ").tap { |e| e.set_backtrace(["f1.rb:12", "f2.rb:51"]) }, extra: "data", is: "here"
[ERROR] extra="data" is="here"
  OH NOEZ (StandardError)
  f1.rb:12
  f2.rb:51
=> true
```

# Exception with extra info extracted from payload

```
irb(main):013:0> logger = Dry.Logger(:test, template: "[%<severity>s] %<verb>s %<path>s %<payload>s")
=> 
#<Dry::Logger::Dispatcher:0x0000000111a31030
...
irb(main):014:0> logger.error StandardError.new("OH NOEZ").tap { |e| e.set_backtrace(["f1.rb:12", "f2.rb:51"]) }, verb: "GET", path: "/users", extra: "data", is: "here"
[ERROR] GET /users extra="data" is="here"
  OH NOEZ (StandardError)
  f1.rb:12
  f2.rb:51
=> true
```