### PR TITLE
Support for colorized output

### DIFF
--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -43,7 +43,7 @@ module Dry
       def initialize(clock:, progname:, severity:, message: nil, payload: EMPTY_HASH)
         @clock = clock
         @progname = progname
-        @severity = severity.to_s.upcase # TODO: this doesn't feel right
+        @severity = severity.to_s
         @level = LEVELS.fetch(severity.to_s)
         @message = message unless message.is_a?(Exception)
         @exception = message if message.is_a?(Exception)

--- a/lib/dry/logger/formatters/colors.rb
+++ b/lib/dry/logger/formatters/colors.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Dry
+  module Logger
+    module Formatters
+      # Shell colorizer
+      #
+      # This was ported from hanami-utils
+      #
+      # @since 1.0.0
+      # @api private
+      class Colors
+        # Unknown color code error
+        #
+        # @since 1.0.0
+        class UnknownColorCodeError < StandardError
+          def initialize(code)
+            super("Unknown color code: `#{code.inspect}'")
+          end
+        end
+
+        # Escapes codes for terminals to output strings in colors
+        #
+        # @since 1.2.0
+        # @api private
+        COLORS = {black: 30,
+                  red: 31,
+                  green: 32,
+                  yellow: 33,
+                  blue: 34,
+                  magenta: 35,
+                  cyan: 36,
+                  gray: 37}.freeze
+
+        # @api private
+        def self.evaluate(input)
+          COLORS.keys.reduce(input.dup) { |output, color|
+            output.gsub!("<#{color}>", start(color))
+            output.gsub!("</#{color}>", stop)
+            output
+          }
+        end
+
+        # Colorizes output
+        # 8 colors available: black, red, green, yellow, blue, magenta, cyan, and gray
+        #
+        # @param input [#to_s] the string to colorize
+        # @param color [Symbol] the color
+        #
+        # @raise [UnknownColorError] if the color code is unknown
+        #
+        # @return [String] the colorized string
+        #
+        # @since 1.0.0
+        # @api private
+        def self.call(color, input)
+          "#{start(color)}#{input}#{stop}"
+        end
+
+        # @since 1.0.0
+        # @api private
+        def self.start(color)
+          "\e[#{self[color]}m"
+        end
+
+        # @since 1.0.0
+        # @api private
+        def self.stop
+          "\e[0m"
+        end
+
+        # Helper method to translate between color names and terminal escape codes
+        #
+        # @since 1.0.0
+        # @api private
+        #
+        # @raise [UnknownColorError] if the color code is unknown
+        def self.[](code)
+          COLORS.fetch(code) { raise UnknownColorCodeError, code }
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/logger/formatters/json.rb
+++ b/lib/dry/logger/formatters/json.rb
@@ -25,6 +25,12 @@ module Dry
 
         # @since 0.1.0
         # @api private
+        def format_severity(value)
+          value.upcase
+        end
+
+        # @since 0.1.0
+        # @api private
         def format_exception(value)
           {
             exception: value.class,

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -31,6 +31,17 @@ module Dry
         # @api private
         EXCEPTION_SEPARATOR = ": "
 
+        # @since 1.2.0
+        # @api private
+        DEFAULT_SEVERITY_COLORS = {
+          DEBUG => :cyan,
+          INFO => :magenta,
+          WARN => :yellow,
+          ERROR => :red,
+          FATAL => :red,
+          UNKNOWN => :blue
+        }.freeze
+
         # @since 1.0.0
         # @api private
         attr_reader :template
@@ -42,7 +53,25 @@ module Dry
           @template = Template[template]
         end
 
+        # @since 1.0.0
+        # @api private
+        def colorize?
+          options[:colorize].equal?(true)
+        end
+
         private
+
+        # @since 1.0.0
+        # @api private
+        def format_severity(value)
+          output = value.upcase
+
+          if colorize?
+            Colors.call(severity_colors[LEVELS[value]], output)
+          else
+            output
+          end
+        end
 
         # @since 1.0.0
         # @api private
@@ -94,6 +123,15 @@ module Dry
           else
             data
           end
+        end
+
+        # @since 1.0.0
+        # @api private
+        def severity_colors
+          @severity_colors ||= DEFAULT_SEVERITY_COLORS.merge(
+            (options[:severity_colors] || EMPTY_HASH)
+              .to_h { |key, value| [LEVELS[key.to_s], value] }
+          )
         end
       end
     end

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -4,11 +4,15 @@ RSpec.describe Dry::Logger::Formatters::String do
   include_context "stream"
 
   subject(:logger) do
-    Dry.Logger(:test, stream: stream, formatter: formatter, template: template)
+    Dry.Logger(:test, stream: stream, formatter: formatter, template: template, **options)
   end
 
   let(:formatter) do
     described_class
+  end
+
+  let(:options) do
+    {}
   end
 
   describe "using customized template with `message` token" do
@@ -73,6 +77,36 @@ RSpec.describe Dry::Logger::Formatters::String do
       logger.info verb: "POST", path: "/users"
 
       expect(output).to eql("[INFO] \e[32mPOST\e[0m \e[36m/users\e[0m\n")
+    end
+  end
+
+  describe "using colorized mode" do
+    let(:template) do
+      "[%<severity>s] %<message>s"
+    end
+
+    context "with default severity colors" do
+      let(:options) do
+        {colorize: true}
+      end
+
+      it "colorizes severity" do
+        logger.info "Hello World"
+
+        expect(output).to eql("[\e[35mINFO\e[0m] Hello World\n")
+      end
+    end
+
+    context "with customized severity colors" do
+      let(:options) do
+        {colorize: true, severity_colors: {info: :blue}}
+      end
+
+      it "colorizes severity using custom color" do
+        logger.info "Hello World"
+
+        expect(output).to eql("[\e[34mINFO\e[0m] Hello World\n")
+      end
     end
   end
 

--- a/spec/dry/logger/formatters/string_spec.rb
+++ b/spec/dry/logger/formatters/string_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe Dry::Logger::Formatters::String do
     end
   end
 
+  describe "using colorized template" do
+    let(:template) do
+      "[%<severity>s] <green>%<verb>s</green> <cyan>%<path>s</cyan>"
+    end
+
+    it "replaces tokens with colorized payload values" do
+      logger.info verb: "POST", path: "/users"
+
+      expect(output).to eql("[INFO] \e[32mPOST\e[0m \e[36m/users\e[0m\n")
+    end
+  end
+
   describe "using customized formatter" do
     let(:formatter) do
       Class.new(described_class) do


### PR DESCRIPTION
This restores `colorize: true` option and introduces support for color tags in string templates.

Supported colors:

```
COLORS = {
  black: 30,
  red: 31,
  green: 32,
  yellow: 33,
  blue: 34,
  magenta: 35,
  cyan: 36,
  gray: 37
}.freeze
```

Here are a couple of usage examples:

```ruby
# to enable coloring of severity
logger = Dry.Logger(:test, colorize: true)

# to enable customize severity colors
logger = Dry.Logger(:test, colorize: true, severity_colors: {info: :blue})

# to use colors in templates
logger = Dry.Logger(:test, template: "<green>%<message>s</green>")
```