### PR TITLE
Make tags a first-class concept

### DIFF
--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -67,12 +67,15 @@ module Dry
 
       # @since 1.0.0
       # @api private
-      def initialize(id, backends: [], context: self.class.default_context, **options)
+      def initialize(
+        id, backends: [], tags: [], context: self.class.default_context, **options
+      )
         @id = id
         @backends = backends
         @options = {**options, progname: id}
         @mutex = Mutex.new
         @context = context
+        @tags = tags
         @clock = Clock.new(**(options[:clock] || EMPTY_HASH))
       end
 
@@ -179,6 +182,7 @@ module Dry
             clock: clock,
             progname: id,
             severity: severity,
+            tags: @tags,
             message: message,
             payload: {**context, **payload}
           )
@@ -204,11 +208,11 @@ module Dry
       #
       # @since 1.0.0
       # @api public
-      def tagged(tag)
-        context[:tag] = tag
+      def tagged(*tags)
+        @tags.concat(tags)
         yield
       ensure
-        context.delete(:tag)
+        @tags = []
       end
 
       # Add a new backend to an existing dispatcher

--- a/lib/dry/logger/entry.rb
+++ b/lib/dry/logger/entry.rb
@@ -20,6 +20,10 @@ module Dry
 
       # @since 1.0.0
       # @api public
+      attr_reader :tags
+
+      # @since 1.0.0
+      # @api public
       attr_reader :level
 
       # @since 1.0.0
@@ -40,15 +44,19 @@ module Dry
 
       # @since 1.0.0
       # @api private
-      def initialize(clock:, progname:, severity:, message: nil, payload: EMPTY_HASH)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(clock:, progname:, severity:, tags: EMPTY_ARRAY, message: nil,
+                     payload: EMPTY_HASH)
         @clock = clock
         @progname = progname
         @severity = severity.to_s
+        @tags = tags
         @level = LEVELS.fetch(severity.to_s)
         @message = message unless message.is_a?(Exception)
         @exception = message if message.is_a?(Exception)
         @payload = build_payload(payload)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # @since 1.0.0
       # @api public
@@ -102,6 +110,12 @@ module Dry
       # @api public
       def key?(name)
         payload.key?(name)
+      end
+
+      # @since 1.0.0
+      # @api public
+      def tag?(value)
+        tags.include?(value)
       end
 
       # @since 1.0.0

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -88,6 +88,20 @@ module Dry
 
         # @since 1.0.0
         # @api private
+        def format_tags(value)
+          Array(value)
+            .map { |tag|
+              case tag
+              when Hash then format_payload(tag)
+              else
+                tag.to_s
+              end
+            }
+            .join(SEPARATOR)
+        end
+
+        # @since 1.0.0
+        # @api private
         def format_exception(value)
           [
             "#{value.message} (#{value.class})",
@@ -113,6 +127,10 @@ module Dry
           data = format_values(entry)
           payload = data.except(:message, *entry.meta.keys, *template.tokens, *exclude)
           data[:payload] = format_payload(payload)
+
+          if template.include?(:tags)
+            data[:tags] = format_tags(entry.tags)
+          end
 
           if data[:message]
             data.except(*payload.keys)


### PR DESCRIPTION
This makes tags a first-class citizen rather than part of the shared logging context. It also makes sure that tags will only be included in log entries when their template actually include `%<tags>s`.