### PR TITLE
Handle crashes

### DIFF
--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -60,6 +60,8 @@ module Dry
   # @option options [String, Symbol] :template (:default) The default template that should be used
   # @option options [Boolean] :colorize (false) Enable/disable colorized severity
   # @option options [Hash<Symbol=>Symbol>] :severity_colors ({}) A severity=>color mapping
+  # @option options [#call] :on_crash (Dry::Logger::Dispatcher::ON_CRASH) A crash-handling proc.
+  #   This is used whenever logging crashes.
   #
   # @since 1.0.0
   # @api public

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -81,6 +81,13 @@ module Dry
 
     register_template(:details, "[%<progname>s] [%<severity>s] [%<time>s] %<message>s %<payload>s")
 
+    register_template(:crash, <<~STR)
+      [%<progname>s] [%<severity>s] [%<time>s] Logging crashed
+        %<log_entry>s
+        %<message>s (%<exception>s)
+      %<backtrace>s
+    STR
+
     register_template(:rack, <<~STR)
       [%<progname>s] [%<severity>s] [%<time>s] \
       %<verb>s %<status>s %<elapsed>s %<ip>s %<path>s %<length>s %<payload>s

--- a/lib/dry/logger/constants.rb
+++ b/lib/dry/logger/constants.rb
@@ -10,13 +10,21 @@ module Dry
 
     # @since 1.0.0
     # @api private
+    SEPARATOR = " "
+
+    # @since 1.0.0
+    # @api private
+    TAB = SEPARATOR * 2
+
+    # @since 1.0.0
+    # @api private
     EMPTY_ARRAY = [].freeze
 
     # @since 1.0.0
     # @api private
     EMPTY_HASH = {}.freeze
 
-    LOG_METHODS = %i[debug error fatal info warn].freeze
+    LOG_METHODS = %i[debug info warn error fatal unknown].freeze
 
     BACKEND_METHODS = %i[close].freeze
 

--- a/lib/dry/logger/formatters/string.rb
+++ b/lib/dry/logger/formatters/string.rb
@@ -17,14 +17,6 @@ module Dry
       class String < Structured
         # @since 1.0.0
         # @api private
-        SEPARATOR = " "
-
-        # @since 1.0.0
-        # @api private
-        TAB = SEPARATOR * 2
-
-        # @since 1.0.0
-        # @api private
         HASH_SEPARATOR = ","
 
         # @since 1.0.0

--- a/spec/shared/stream.rb
+++ b/spec/shared/stream.rb
@@ -17,8 +17,12 @@ RSpec.shared_context "stream" do
     end.new
   end
 
-  let(:output) do
-    stream.string
+  def output(*args)
+    if args.empty?
+      stream.string
+    else
+      super
+    end
   end
 
   let(:now) do


### PR DESCRIPTION
This adds crash-handling option `on_crash` that is executed whenever an exception is raised while logging. We provide a default proc defined as `Dry::Logger::Dispatcher::ON_CRASH`.

```ruby
> logger = Dry.Logger(:test, template: "%<foo>s %<bar>s")
=> #<Dry::Logger::Dispatcher:...

> logger.info foo: "hello", bar: "world"
hello world
=> true

> logger.info foo: "hello"
[test] [FATAL] [2022-11-16 10:18:51 +0100] Logging crashed
  {:foo=>"hello"}
  key<bar> not found (KeyError)
  /Users/solnic/Workspace/dry-rb/dry-logger/lib/dry/logger/formatters/template.rb:73:in `%'
  /Users/solnic/Workspace/dry-rb/dry-logger/lib/dry/logger/formatters/template.rb:73:in `%'
  /Users/solnic/Workspace/dry-rb/dry-logger/lib/dry/logger/formatters/string.rb:77:in `format'
  /Users/solnic/Workspace/dry-rb/dry-logger/lib/dry/logger/formatters/structured.rb:55:in `call'
  /Users/solnic/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/logger.rb:586:in `format_message'
...
# true
```