### PR TITLE
Handle `:log_if` in Proxy constructors

### DIFF
--- a/lib/dry/logger/backends/proxy.rb
+++ b/lib/dry/logger/backends/proxy.rb
@@ -35,6 +35,14 @@ module Dry
           end
         end
 
+        # @since 1.0.2
+        # @api private
+        def initialize(backend, **options)
+          super(backend)
+          @options = options
+          self.log_if = @options[:log_if]
+        end
+
         # @since 1.0.0
         # @api private
         def log?(entry)

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -260,7 +260,7 @@ module Dry
         backend =
           case (instance ||= Dry::Logger.new(**options, **backend_options))
           when Backends::Stream then instance
-          else Backends::Proxy.new(instance)
+          else Backends::Proxy.new(instance, **options, **backend_options)
           end
 
         yield(backend) if block_given?

--- a/spec/dry/logger/backends/proxy_spec.rb
+++ b/spec/dry/logger/backends/proxy_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe Dry::Logger::Backends::Proxy do
 
   it "supports shortcut log_if" do
     backend = test_backend do
+      def info(message)
+        @stream.write(message)
+      end
+
       def error(message)
         @stream.write(message)
       end
@@ -94,8 +98,10 @@ RSpec.describe Dry::Logger::Backends::Proxy do
 
     logger = Dry.Logger(:test) { |s| s.add_backend(backend, log_if: :error?) }
 
-    logger.error("Hello World")
+    logger.info("Hello World")
+    logger.error("Oops")
 
-    expect(output).to eql("Hello World")
+    expect(stream).to_not include("Hello World")
+    expect(stream).to include("Oops")
   end
 end


### PR DESCRIPTION
This should be consolidated eventually, unfortunately the stdlib constructor got in the way 🙂 Anyhow, this fixes a bug where passing `log_if` as *a kwarg option* to `add_backend` with an external logger that should be proxied, would end up *not setting this option* on the proxy itself.

So, now this works:

```ruby
Dry.Logger(:test).add_backend(Rollbar, log_if: :exception?)
```