### PR TITLE
Accept log messages via block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /_yardoc/
 /coverage/
 /doc/
+/log/
 /pkg/
 /spec/reports/
 /tmp/

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -37,6 +37,9 @@ logger = Dry.Logger(:test, template: :details)
 
 logger.info "Hello World"
 # [test] [INFO] [2022-11-17 11:43:52 +0100] Hello World
+
+logger.info { "Hello World from a block" }
+# [test] [INFO] [2022-11-17 11:44:12 +0100] Hello World from a block
 ```
 
 ### Using multiple logging destinations

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -110,8 +110,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def unknown(message = nil, **payload)
-        log(:unknown, message, **payload)
+      def unknown(message = nil, **payload, &block)
+        log(:unknown, message, **payload, &block)
       end
 
       # Log an entry with DEBUG severity
@@ -119,8 +119,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def debug(message = nil, **payload)
-        log(:debug, message, **payload)
+      def debug(message = nil, **payload, &block)
+        log(:debug, message, **payload, &block)
       end
 
       # Log an entry with INFO severity
@@ -128,8 +128,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def info(message = nil, **payload)
-        log(:info, message, **payload)
+      def info(message = nil, **payload, &block)
+        log(:info, message, **payload, &block)
       end
 
       # Log an entry with WARN severity
@@ -137,8 +137,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def warn(message = nil, **payload)
-        log(:warn, message, **payload)
+      def warn(message = nil, **payload, &block)
+        log(:warn, message, **payload, &block)
       end
 
       # Log an entry with ERROR severity
@@ -146,8 +146,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def error(message = nil, **payload)
-        log(:error, message, **payload)
+      def error(message = nil, **payload, &block)
+        log(:error, message, **payload, &block)
       end
 
       # Log an entry with FATAL severity
@@ -155,8 +155,8 @@ module Dry
       # @see Dispatcher#log
       # @api public
       # @return [true]
-      def fatal(message = nil, **payload)
-        log(:fatal, message, **payload)
+      def fatal(message = nil, **payload, &block)
+        log(:fatal, message, **payload, &block)
       end
 
       BACKEND_METHODS.each do |name|
@@ -179,6 +179,9 @@ module Dry
       # @example logging a message
       #   logger.log(:info, "Hello World")
       #
+      # @example logging a message by passing a block
+      #   logger.log(:debug, "Sidecar") { "Hello World" }
+      #
       # @example logging payload
       #   logger.log(:info, verb: "GET", path: "/users")
       #
@@ -196,17 +199,25 @@ module Dry
       # @param [Symbol] severity The log severity name
       # @param [String] message Optional message
       # @param [Hash] payload Optional log entry payload
+      # @yield
+      # @yieldreturn [String] Message to be logged
       #
       # @since 1.0.0
       # @return [true]
       # @api public
-      def log(severity, message = nil, **payload)
+      def log(severity, message = nil, **payload, &block)
         case message
-        when Hash then log(severity, nil, **message)
+        when Hash then log(severity, **message, &block)
         else
+          if block
+            progname = message
+            message = block.call
+          end
+          progname ||= id
+
           entry = Entry.new(
             clock: clock,
-            progname: id,
+            progname: progname,
             severity: severity,
             tags: @tags,
             message: message,

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -43,6 +43,42 @@ RSpec.describe Dry::Logger do
     end
   end
 
+  context "using progname" do
+    subject(:logger) { Dry.Logger(:test, stream: stream, template: "%<progname>s: %<message>s %<payload>s") }
+
+    it "uses the logger ID as the progname" do
+      message = "hello, world"
+
+      logger.info(message)
+
+      expect(output).to match("test: #{message}")
+    end
+
+    it "replaces the default progname with the progname: keyword argument" do
+      message = "hello, world"
+
+      logger.info(message, progname: "newprog", test: true)
+
+      expect(output).to match("newprog: #{message} test=true")
+    end
+
+    it "replaces the progname with the first string argument when the message is given as a block" do
+      message = "hello, world"
+
+      logger.info("newprog") { message }
+
+      expect(output).to match("newprog: hello, world")
+    end
+
+    it "replaces the progname with the progname: keyword argument when the message is given as a block" do
+      message = "hello, world"
+
+      logger.info(progname: "newprog", test: true) { message }
+
+      expect(output).to match("newprog: #{message} test=true")
+    end
+  end
+
   context "adding backends via block only" do
     it "doesn't setup the default logger" do
       logger = Dry.Logger(:test, stream: stream) { |setup|

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Dry::Logger do
 
       expect(output).to match("#{message} test=true")
     end
+
+    it "logs to $stdout by default using a plain text block message" do
+      message = "hello, world"
+
+      logger.info { message }
+
+      expect(output).to match(message)
+    end
+
+    it "logs to $stdout by default using a plain text block message and payload" do
+      message = "hello, world"
+
+      logger.info(test: true) { message }
+
+      expect(output).to match("#{message} test=true")
+    end
   end
 
   context "adding backends via block only" do


### PR DESCRIPTION
fixes #25

---

This patch allows a Dry-Logger instance to accept log messages via a block.

If a block is passed to `#unknown`, `#debug`, `#info`, `#warn`, `#error`, or
`#fatal`, the block's return value becomes the logged message much like the
Ruby standardlib Logger.

```ruby
l = Dry.Logger(:testymctestface, template: :details)
# => #<Dry::Logger::Dispatcher ...

l.info('regular positional argument message')
# [testymctestface] [INFO] [2024-05-01 07:35:36 -0400] regular positional argument message
# => true

l.info { 'a block message' }
# [testymctestface] [INFO] [2024-05-01 07:35:50 -0400] a block message
# => true

l.info('sub-component') { 'fancy-pants block message' }
# [sub-component] [INFO] [2024-05-01 07:36:09 -0400] fancy-pants block message
# => true
```

I added two spec tests to ensure that block passing works, but I wasn't able to
quickly figure out how to check the value of `progname`.

---

Thank you for considering my patch!
