### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-if RUBY_VERSION < "3"
-  gem "backports"
-end
-
 group :test do
   gem "sequel"
   gem "sqlite3"

--- a/lib/dry/logger.rb
+++ b/lib/dry/logger.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-if RUBY_VERSION < "3"
-  require "backports/3.0.0/hash/except"
-end
-
 require "dry/logger/global"
 require "dry/logger/constants"
 require "dry/logger/clock"


### PR DESCRIPTION
We gave Ruby 2.7 a good run of support in the 1 year and 5 months since we added it in v1.0.3.

Ruby 2.7 is well past EOL now, so I'm dropping support in line with standard dry-rb policy (of supporting only non-EOL Ruby versions).

Technically, 3.0 support could also be removed (since it is also EOL), but I'm leaving it here for now.