### PR TITLE
Don't execute block if severity is less than logger level

### DIFF
--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -206,6 +206,7 @@ module Dry
       # @return [true]
       # @api public
       def log(severity, message = nil, **payload, &block)
+        return true if LEVELS[severity] < level
         case message
         when Hash then log(severity, **message, &block)
         else

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Dry::Logger do
 
       expect(output).to match("#{message} test=true")
     end
+
+    it "does not execute the block if severity is higher" do
+      logger.debug { raise }
+    end
   end
 
   context "using progname" do


### PR DESCRIPTION
When logging with a block, don't execute the block if the output won't be logged because the severity is less than the logger level.

This should improve performance and is also implemented by Ruby's default logger:
https://github.com/ruby/ruby/blob/48d4efcb85000e1ebae42004e963b5d0cedddcf2/lib/logger.rb#L658-L660