### PR TITLE
Support passing payloads in blocks

### DIFF
--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -211,7 +211,12 @@ module Dry
         else
           if block
             progname = message
-            message = block.call
+            block_result = block.call
+            case block_result
+            when Hash then payload = block_result
+            else
+              message = block_result
+            end
           end
           progname ||= id
 

--- a/spec/dry/logger_spec.rb
+++ b/spec/dry/logger_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Dry::Logger do
       expect(output).to match(message)
     end
 
+    it "logs to $stdout by default using a payload block" do
+      message = "hello, world"
+
+      logger.info { { test: true } }
+
+      expect(output).to match("test=true")
+    end
+
     it "logs to $stdout by default using a plain text block message and payload" do
       message = "hello, world"
 
@@ -41,6 +49,15 @@ RSpec.describe Dry::Logger do
 
       expect(output).to match("#{message} test=true")
     end
+
+    it "logs to $stdout by default using a plain text message and payload block" do
+      message = "hello, world"
+
+      logger.info(message) { { test: true } }
+
+      expect(output).to match("#{message} test=true")
+    end
+
   end
 
   context "using progname" do


### PR DESCRIPTION
Hanami passes the payload instead of a message:
https://github.com/hanami/hanami/blob/d7bce6d7d6a01957a5bb8f5964495b9e7afd7fe3/lib/hanami/web/rack_logger.rb#L148

This allows passing a Hash to the block so we can optionally execute the block when the severity is lower than the log level.

```ruby
logger.info do
  data(env, status: status, elapsed: elapsed)
end
```