### PR TITLE
Handle encodings difference between message and payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Fixed
 
+- Exception when message and metadata have different encodings (@katafrakt in #40)
+
 ### Security
 
 [Unreleased]: https://github.com/dry-rb/dry-logger/compare/v1.2.1...main

--- a/lib/dry/logger/dispatcher.rb
+++ b/lib/dry/logger/dispatcher.rb
@@ -53,7 +53,9 @@ module Dry
           severity: "FATAL",
           progname: progname,
           time: Time.now,
-          log_entry: [message, payload].map(&:to_s).reject(&:empty?).join(SEPARATOR),
+          log_entry: [message, payload].map { |s|
+            s.to_s.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+          }.reject(&:empty?).join(SEPARATOR),
           exception: exception.class,
           message: exception.message,
           backtrace: TAB + exception.backtrace.join(NEW_LINE + TAB)

--- a/lib/dry/logger/formatters/template.rb
+++ b/lib/dry/logger/formatters/template.rb
@@ -68,8 +68,19 @@ module Dry
 
         # @since 1.0.0
         # @api private
-        def %(tokens)
-          output = value % tokens
+        def %(other)
+          begin
+            output = value % other
+          rescue Encoding::CompatibilityError
+            sanitized_tokens = other.transform_values { |v|
+              if v.respond_to?(:encode)
+                v.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?")
+              else
+                v
+              end
+            }
+            output = value % sanitized_tokens
+          end
           output.strip!
           output.split(NEW_LINE).map(&:rstrip).join(NEW_LINE)
         end

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe Dry::Logger::Dispatcher do
 
         expect(stream).to include(message)
       end
+
+      it "handles encoding mismatches between message and payload in normal logging" do
+        message = +"\xFF\xFEnormal"
+        message.force_encoding("ASCII-8BIT")
+
+        payload = {data: "café"}
+
+        logger.public_send(level, message, **payload)
+        expect(stream).to include('??normal data="café"')
+      end
     end
 
     describe "##{level} when a custom backend crashes" do
@@ -41,6 +51,15 @@ RSpec.describe Dry::Logger::Dispatcher do
         # TODO: for some reason output matcher doesn't work here
         # .     so this is going to spit things out in the test output
         expect { logger.public_send(level, "Hello World!") }.to_not raise_error
+      end
+
+      it "handles encoding mismatches between message and payload" do
+        message = +"\xFF\xFEnormal"
+        message.force_encoding("ASCII-8BIT")
+
+        payload = {data: "café"}
+
+        expect { logger.public_send(level, message, **payload) }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
I encountered an error in Hanami. Apparently the errors from SQLite are encoded with ASCII-8BIT, which - when attempted to join with UTF-8 payload - leads to encoding error.

<img width="1494" height="882" alt="Screenshot 2026-03-12 at 17 45 52" src="https://github.com/user-attachments/assets/a3eaa704-d24f-4c43-b662-3c8816e5c53c" />

This introduces normalization of encodings before joining.