### PR TITLE
Fork of the original dry-logger with fiber-safe contexts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 # dry-logger [![Gem Version](https://badge.fury.io/rb/dry-logger.svg)][rubygem] [![CI Status](https://github.com/dry-rb/dry-logger/workflows/CI/badge.svg)][actions]
 
-[![Forum](https://img.shields.io/badge/Forum-dc360f?logo=discourse&logoColor=white)][forum]
-[![Chat](https://img.shields.io/badge/Chat-717cf8?logo=discord&logoColor=white)][chat]
+This is a fork of the original **dry-logger** that supports fiber-safe isolation. The main difference is that child fibers inherit the parent context, with copy-on-write semantics for any modifications.
 
 ## Links
 
@@ -19,4 +18,3 @@
 ## License
 
 See `LICENSE` file.
-

--- a/lib/dry/logger/execution_context.rb
+++ b/lib/dry/logger/execution_context.rb
@@ -2,7 +2,7 @@
 
 module Dry
   module Logger
-    # Provides isolated thread-local storage for logger values.
+    # Provides isolated fiber-local storage for logger values.
     #
     # @api private
     module ExecutionContext
@@ -19,13 +19,16 @@ module Dry
         end
 
         # Sets a value in the current execution context.
+        # Use copy-on-write for the inherited CONTEXT_KEY hash.
         #
         # @param key [Symbol] the key to store
         # @param value [Object] the value to store
         #
         # @return [Object] the stored value
         def []=(key, value)
-          context[key] = value
+          current_store[CONTEXT_KEY] = context.merge(key => value)
+
+          context[key]
         end
 
         # Clears all values from the current execution context.
@@ -43,7 +46,7 @@ module Dry
         end
 
         def current_store
-          Thread.current
+          Fiber
         end
       end
     end

--- a/spec/dry/logger/dispatcher_spec.rb
+++ b/spec/dry/logger/dispatcher_spec.rb
@@ -272,49 +272,49 @@ RSpec.describe Dry::Logger::Dispatcher do
     end
   end
 
-  describe "thread safety" do
+  describe "fiber safety" do
     subject(:logger) do
       Dry.Logger(:test, stream: stream, template: "[%<tags>s] %<message>s %<payload>s", context: {})
     end
 
-    it "isolates tags across threads" do
-      threads = []
+    it "isolates tags across fibers" do
+      fibers = []
 
       5.times do |i|
-        threads << Thread.new do
-          logger.tagged(:"thread_#{i}") do
+        fibers << Fiber.new do
+          logger.tagged(:"fiber_#{i}") do
             sleep(rand * 0.01)
             logger.info("message #{i}")
           end
         end
       end
 
-      threads.each(&:join)
+      fibers.each(&:resume)
 
       lines = stream.string.lines
       5.times do |i|
         line = lines.find { |l| l.include?("message #{i}") }
-        expect(line).to include("[thread_#{i}]")
+        expect(line).to include("[fiber_#{i}]")
       end
     end
 
-    it "isolates context across threads" do
-      threads = []
+    it "isolates context across fibers" do
+      fibers = []
 
       5.times do |i|
-        threads << Thread.new do
-          logger.context[:thread_id] = i
+        fibers << Fiber.new do
+          logger.context[:fiber_id] = i
           sleep(rand * 0.01)
           logger.info("message #{i}")
         end
       end
 
-      threads.each(&:join)
+      fibers.each(&:resume)
 
       lines = stream.string.lines
       5.times do |i|
         line = lines.find { |l| l.include?("message #{i}") }
-        expect(line).to include("thread_id=#{i}")
+        expect(line).to include("fiber_id=#{i}")
       end
     end
   end

--- a/spec/dry/logger/execution_context_spec.rb
+++ b/spec/dry/logger/execution_context_spec.rb
@@ -46,19 +46,58 @@ RSpec.describe Dry::Logger::ExecutionContext do
   end
 
   describe "thread isolation" do
-    it "isolates storage between threads" do
+    it "makes copy on write in new thread" do
+      context[:main] = "main_value"
+
+      thread = Thread.new do
+        context[:main] = "new_value"
+        context[:fiber] = "fiber_value"
+      end
+      thread.join
+
+      expect(context[:main]).to eq("main_value")
+      expect(context[:fiber]).to be_nil
+    end
+
+    it "inherits parent thread fiber storage in new thread" do
       context[:main] = "main_value"
 
       thread_value = nil
       thread = Thread.new do
-        context[:thread] = "thread_value"
         thread_value = context[:main]
       end
       thread.join
 
       expect(context[:main]).to eq("main_value")
-      expect(context[:thread]).to be_nil
-      expect(thread_value).to be_nil
+      expect(thread_value).to eq("main_value")
+    end
+  end
+
+  describe "fiber isolation" do
+    it "makes copy on write in new fiber" do
+      context[:main] = "main_value"
+
+      fiber = Fiber.new do
+        context[:main] = "new_value"
+        context[:fiber] = "fiber_value"
+      end
+      fiber.resume
+
+      expect(context[:main]).to eq("main_value")
+      expect(context[:fiber]).to be_nil
+    end
+
+    it "inherits parent storage in new fiber" do
+      context[:main] = "main_value"
+
+      fiber_value = nil
+      fiber = Fiber.new do
+        fiber_value = context[:main]
+      end
+      fiber.resume
+
+      expect(context[:main]).to eq("main_value")
+      expect(fiber_value).to eq("main_value")
     end
   end
 end


### PR DESCRIPTION
- Change ExecutionContext from threads to fibers
- Chagne specs to handle fibers and storage inheriting